### PR TITLE
Implements another strategy to get the routes

### DIFF
--- a/lib/node.py
+++ b/lib/node.py
@@ -349,6 +349,53 @@ class LndNode(Node):
             channel_id = convert_short_channel_id_to_channel_id(*short_channel_groups)
             return channel_id
 
+    def queryroute_external(self, source_pubkey, target_pubkey, amt_msat, ignored_nodes=(), ignored_channels=()):
+        """
+        Queries the lnd node for a route. Channels and nodes can be ignored if they failed before.
+
+        :param source_pubkey: str
+        :param target_pubkey: str
+        :param amt_msat: int
+        :param ignored_nodes: list of node pub keys
+        :param ignored_channels: list of channel_ids
+        :return: list of channel_ids
+        """
+        amt_sat = amt_msat // 1000
+
+        # we want to see all routes:
+        max_fee = 10000
+
+        # convert ignored nodes to api format
+        if ignored_nodes:
+            ignored_nodes_api = [bytes.fromhex(n) for n in ignored_nodes]
+        else:
+            ignored_nodes_api = []
+
+        # convert ignored channels to api format
+        if ignored_channels:
+            ignored_channels_api = [ln.EdgeLocator(channel_id=c) for c in ignored_channels]
+        else:
+            ignored_channels_api = []
+
+        logger.debug(f"Ignored for queryroutes: channels: {ignored_channels_api}, nodes: {ignored_nodes_api}")
+
+        request = ln.QueryRoutesRequest(
+            pub_key=target_pubkey,
+            amt=amt_sat,
+            num_routes=1,
+            final_cltv_delta=0,
+            fee_limit=ln.FeeLimit(fixed=max_fee),
+            ignored_nodes=ignored_nodes_api,
+            ignored_edges=ignored_channels_api,
+            source_pub_key=source_pubkey,
+        )
+        response = self._stub.QueryRoutes(request)
+
+        # We give back only one route, as multiple routes will be deprecated
+        channel_route = [h.chan_id for h in response.routes[0].hops]
+
+        return channel_route
+
 
 if __name__ == '__main__':
     import logging.config

--- a/lib/pathfinding.py
+++ b/lib/pathfinding.py
@@ -20,12 +20,11 @@ def ksp_discard_high_cost_paths(graph, source, target, num_k, weight):
     """
     final_routes = []
     routes, route_costs = ksp(graph, source, target, num_k, weight)
-    logger.debug("Approximate costs [msats] of routes before discarding paths:")
-    logger.debug(route_costs)
+    logger.debug("Approximate costs [msats] of routes:")
     for r, rc in zip(routes, route_costs):
         if rc < _settings.PENALTY:
+            logger.debug(f"  {rc} msat: {r}")
             final_routes.append(r)
-    logger.debug(f"Number of routes after discarding paths: {len(final_routes)}")
     return final_routes
 
 

--- a/lib/rebalance.py
+++ b/lib/rebalance.py
@@ -256,7 +256,7 @@ class Rebalancer(object):
             raise ValueError("Chunk size must be between 0.0 and 1.0")
 
         logger.info(f">>> Trying to rebalance channel {channel_id} with a max rate of {self.max_effective_fee_rate}"
-                    f"and a max fee of {self.budget_sat} sat.")
+                    f" and a max fee of {self.budget_sat} sat.")
         logger.info(f">>> Chunk size is set to {chunksize}.")
 
         if dry:
@@ -281,8 +281,10 @@ class Rebalancer(object):
 
         logger.info(f">>> There are {len(rebalance_candidates)} channels with which we can rebalance (look at logfile).")
         logger.info(f">>> We will try to rebalance with them one after the other.")
-        logger.info(f">>> NOTE: only individual rebalance requests are optimized for fees,"
-                    f" use --dry flag to get a feeling (we aim here for a high success rate).")
+        logger.info(f">>> NOTE: only individual rebalance requests are optimized for fees:\n"
+                    f"    this means that there can be rebalances with less fees afterwards,\n"
+                    f"    so take a look at the dry runs first, i.e. without the --reckless flag,\n"
+                    f"    and set --max-fee-sat and --max-fee-rate accordingly.")
         logger.info(f">>> Rebalancing can take some time. Please be patient!\n")
 
         self.print_rebalance_candidates(rebalance_candidates)

--- a/tests/lnd/test_lnd_api.py
+++ b/tests/lnd/test_lnd_api.py
@@ -1,7 +1,29 @@
+import unittest
+import codecs
+
 from lib.node import LndNode
 import grpc_compiled.rpc_pb2 as ln
 
-node = LndNode()
 
-channel = node._stub.GetChanInfo(ln.ChanInfoRequest(chan_id=000000000000000000))
-print(channel.node1_policy.fee_base_msat)
+class TestLndAPI(unittest.TestCase):
+    def setUp(self):
+        self.node = LndNode()
+
+    def test_chan_info_request(self):
+        channel = self.node._stub.GetChanInfo(ln.ChanInfoRequest(chan_id=000000000000000000))
+        print(channel.node1_policy.fee_base_msat)
+
+    def test_queryroutes(self):
+        request = ln.QueryRoutesRequest(
+            pub_key='100000000000000000000000000000000000000000000000000000000000000000',
+            amt=100,
+            num_routes=1,
+            final_cltv_delta=0,
+            fee_limit=ln.FeeLimit(fixed=20),
+            ignored_nodes=[bytes.fromhex('200000000000000000000000000000000000000000000000000000000000000000')],
+            ignored_edges=[ln.EdgeLocator(channel_id=000000000000000000)],
+            source_pub_key='300000000000000000000000000000000000000000000000000000000000000000',
+        )
+
+        response = self.node._stub.QueryRoutes(request)
+        print(response)

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -20,8 +20,18 @@ class TestRouter(TestCase):
         node_from = '000000000000000000000000000000000000000000000000000000000000000000'
         node_to = '000000000000000000000000000000000000000000000000000000000000000000'
         amt = 100
-        routes = self.router.get_routes_along_nodes(node_from, node_to, amt, number_of_routes=2)
+        routes = self.router.get_routes_from_to_nodes(node_from, node_to, amt, number_of_routes=2)
         print(routes)
+
+    def test_queryroute_external(self):
+        node_from = '000000000000000000000000000000000000000000000000000000000000000000'
+        node_to = '000000000000000000000000000000000000000000000000000000000000000000'
+        amt = 100
+        channel_route = self.node.queryroute_external(node_from, node_to, amt)
+        print(channel_route)
+        channel_route = self.node.queryroute_external(
+            node_from, node_to, amt, ignored_channels=[000000000000000000])
+        print(channel_route)
 
     def test_route(self):
         """
@@ -32,12 +42,12 @@ class TestRouter(TestCase):
 
         route = Route(self.node, [000000000000000000, 000000000000000000],
                       '000000000000000000000000000000000000000000000000000000000000000000', 333000)
-        route.debug_route()
+        route._debug_route()
         print('\nFinal route with reverse chain of fees:')
         print(self.node.lnd_route(route))
 
     def test_node_route_to_channel_route(self):
-        hops = self.router.node_route_to_channel_route(
+        hops = self.router._node_route_to_channel_route(
             ['000000000000000000000000000000000000000000000000000000000000000000',
              '000000000000000000000000000000000000000000000000000000000000000000',
              '000000000000000000000000000000000000000000000000000000000000000000', ],
@@ -45,5 +55,5 @@ class TestRouter(TestCase):
         print(hops)
 
     def test_get_routes_for_advanced_rebalancing(self):
-        self.router.get_routes_for_advanced_rebalancing(
-            000000000000000000, 000000000000000000, 100, number_of_routes=10)
+        self.router.get_routes_for_rebalancing(
+            000000000000000000, 000000000000000000, 100)


### PR DESCRIPTION
The route computation is done internally using networkx right now. This is relatively slow and doesn't really scale. With this pull request we externalize the route computation to the lnd node, where bugs are less likely than in our implementation. Still with the time overhead of API crosstalk, this method is faster than the internal one.

The external route finding is still disabled, as there is still a bug in the queryroutes command lightning (lightningnetwork/lnd#2950). Also the internal route computation is kept as an alternative, if for example one would like to support other lightning network implementations.

This pull request also improves the (debug) output for better user interaction.