### PR TITLE
Catch channel key error when rebalancing

### DIFF
--- a/lib/routing.py
+++ b/lib/routing.py
@@ -233,7 +233,12 @@ class Router(object):
         """
 
         channel_from = self.node.network.edges[chan_id_from]
-        channel_to = self.node.network.edges[chan_id_to]
+        try:
+            channel_to = self.node.network.edges[chan_id_to]
+        except KeyError:
+            logger.exception("Channel was not found in network graph, but is present in listchannels.")
+            raise NoRouteError
+
         this_node = self.node.pub_key
 
         # determine nodes on the other side, between which we need to find a suitable path between


### PR DESCRIPTION
Should fix #7. Solution for now is to log the exception for further investigation and fail with a no route error to proceed with rebalancing.