### PR TITLE
rebalance: add rebalancing target and strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,35 @@ lndmanage is a command line tool for advanced channel management of an [`LND`](h
 
 Current feature list (use the ```--help``` flag for subcommands):
 
-* advanced node summary (```status```)
+* advanced node summary ```status```
 * compact ```listchannels``` commands:
-  * list channels for rebalancing (```listchannels rebalance```)
-  * list inactive channels for channel hygiene (```listchannels inactive```)
-  * list forwarding statistics for each channel (```listchannels forwardings```)
-* rebalancing of channels (```rebalance```)
-* doing circular self-payments (```circle```)
+  * list channels for rebalancing ```listchannels rebalance```
+  * list inactive channels for channel hygiene ```listchannels inactive```
+  * list forwarding statistics for each channel ```listchannels forwardings```
+* rebalancing of channels ```rebalance```
+  * different strategies can be chosen
+  * a target 'balancedness' can be specified (e.g. to empty the channel)
+* doing circular self-payments ```circle```
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
+
+Command line options
+--------------------
+```sh
+usage: lndmanage.py [-h] [--loglevel {INFO,DEBUG}]
+                    {status,listchannels,rebalance,circle} ...
+
+Lightning network daemon channel management tool.
+
+positional arguments:
+  {status,listchannels,rebalance,circle}
+    status              display node status
+    listchannels        lists channels with extended information [see also
+                        subcommands with -h]
+    rebalance           rebalance a channel
+    circle              circular self-payment
+
+```
 
 Rebalancing a channel
 ---------------------

--- a/lib/node.py
+++ b/lib/node.py
@@ -278,9 +278,7 @@ class LndNode(Node):
                           'fee_rate_milli_msat': -1}
 
             # define unbalancedness |ub| large means very unbalanced
-            commit_fee = 0
-            if c.initiator:
-                commit_fee = c.commit_fee
+            commit_fee = 0 if not c.initiator else c.commit_fee
             unbalancedness = -(float(c.local_balance + commit_fee) / c.capacity - 0.5) * 2
             # inverse of above formula:
             # c.local_balance = c.capacity * 0.5 * (-unbalancedness + 1) - commit_fee

--- a/lib/node.py
+++ b/lib/node.py
@@ -54,8 +54,8 @@ class LndNode(Node):
         self._stub = self.connect()
         self.network = Network(self)
         self.update_blockheight()
-        self.public_active_channels = self.get_channels(public_only=True, active_only=True)
         self.set_info()
+        self.public_active_channels = self.get_channels(public_only=True, active_only=True)
 
     @staticmethod
     def connect():
@@ -219,6 +219,12 @@ class LndNode(Node):
         """
 
         raw_info = self.get_raw_info()
+        self.pub_key = raw_info.identity_pubkey
+        self.alias = raw_info.alias
+        self.num_active_channels = raw_info.num_active_channels
+        self.num_peers = raw_info.num_peers
+
+        # TODO: remove the following code and implement an advanced status
         all_channels = self.get_channels(active_only=False, public_only=False)
 
         for c in all_channels:
@@ -231,11 +237,6 @@ class LndNode(Node):
                 self.total_active_channels += 1
             if c['private']:
                 self.total_private_channels += 1
-            self.alias = raw_info.alias
-            self.pub_key = raw_info.identity_pubkey
-            self.total_channels = len(self.public_active_channels)
-            self.num_active_channels = raw_info.num_active_channels
-            self.num_peers = raw_info.num_peers
 
     def get_channels(self, active_only=False, public_only=False):
         """
@@ -249,6 +250,7 @@ class LndNode(Node):
         raw_channels = self._stub.ListChannels(ln.ListChannelsRequest(active_only=active_only, public_only=public_only))
         channels_data = raw_channels.ListFields()[0][1]
         channels = []
+
         for c in channels_data:
             # calculate age from blockheight
             blockheight, _, _ = convert_channel_id_to_short_channel_id(c.chan_id)
@@ -262,31 +264,37 @@ class LndNode(Node):
                 last_update = float('nan')
 
             sent_received_per_week = int((c.total_satoshis_sent + c.total_satoshis_received) / (age_days / 7))
-
             # determine policy
-            if self.pub_key < c.remote_pubkey:  # interested in node1
-                policy_node = 'node1_policy'
-            else:  # interested in node2
-                policy_node = 'node2_policy'
+
             try:
-                policy = self.network.edges[c.chan_id][policy_node]
+                edge_info = self.network.edges[c.chan_id]
+                if edge_info['node1_pub'] == self.pub_key:  # interested in node2
+                    policy = edge_info['node2_policy']
+                else:  # interested in node1
+                    policy = edge_info['node1_policy']
             except KeyError:
                 # TODO: if channel is unknown in describegraph we need to set the fees to some error value
                 policy = {'fee_base_msat': -1,
                           'fee_rate_milli_msat': -1}
 
             # define unbalancedness |ub| large means very unbalanced
-            unbalancedness = -(float(c.local_balance) / c.capacity - 0.5) / 0.5
+            commit_fee = 0
+            if c.initiator:
+                commit_fee = c.commit_fee
+            unbalancedness = -(float(c.local_balance + commit_fee) / c.capacity - 0.5) * 2
+            # inverse of above formula:
+            # c.local_balance = c.capacity * 0.5 * (-unbalancedness + 1) - commit_fee
 
             channels.append({
                 'active': c.active,
                 'age': age_days,
                 'alias': self.network.get_node_alias(c.remote_pubkey),
-                'amt_to_balanced': int(abs(unbalancedness * c.capacity / 2)),
+                'amt_to_balanced': int(unbalancedness * c.capacity / 2 - commit_fee),
                 'capacity': c.capacity,
                 'chan_id': c.chan_id,
                 'channel_point': c.channel_point,
                 'commit_fee': c.commit_fee,
+                'fee_per_kw': c.fee_per_kw,
                 'peer_base_fee': policy['fee_base_msat'],
                 'peer_fee_rate': policy['fee_rate_milli_msat'],
                 'initiator': c.initiator,

--- a/lib/rebalance.py
+++ b/lib/rebalance.py
@@ -1,43 +1,12 @@
 import logging
+import math
 
 import _settings
 from lib.exceptions import NoRouteError, RebalanceFailure, DryRunException, PaymentTimeOut, TooExpensive
 from lib.routing import Router
-from lib.user import yes_no_question
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-
-
-def manual_rebalance(node, channel_id_from, channel_id_to, amt, number_of_routes=10):
-    """
-    Attempts several times to rebalance channel_id_from to channel_id_to with amt satoshis,
-    asking for permission.
-
-    :param node: object
-    :param channel_id_from:
-    :param channel_id_to:
-    :param amt: amount in satoshi
-    :param number_of_routes:
-    """
-
-    router = Router(node)
-    amt_msat = amt * 1000
-    logger.info(
-        f"-------- Attempting advanced rebalancing of {amt_msat} msats"
-        f" from channel {channel_id_from} to {channel_id_to}. --------")
-
-    routes = router.get_routes_for_rebalancing(
-        channel_id_from, channel_id_to, amt_msat, number_of_routes
-    )
-    logger.info("Found {} cheapest routes".format(len(routes)))
-
-    node.update_blockheight()
-    for r in routes:
-        logger.info("Do you want to try the following route with a fee of {} msats [Y/n]?".format(r.total_fee_msat))
-        if yes_no_question():
-            node.self_payment_zero_invoice(
-                r, memo=f"lndmanage: Rebalance from {channel_id_from} to {channel_id_to}: {amt} sats")
 
 
 class Rebalancer(object):
@@ -64,15 +33,15 @@ class Rebalancer(object):
                                dry=False):
         """
         Rebalances from channel_id_from to channel_id_to with an amount of amt_sat. A prior created invoice hash
-        has to be given. The budget_sat sets the maxmimum fees that will be paid. A dry run can be done.
+        has to be given. The budget_sat sets the maxmimum fees in sat that will be paid. A dry run can be done.
 
-        :param channel_id_from:
-        :param channel_id_to:
-        :param amt_sat:
-        :param invoice_r_hash:
-        :param budget_sat:
+        :param channel_id_from: int
+        :param channel_id_to: int
+        :param amt_sat: int
+        :param invoice_r_hash: bytes
+        :param budget_sat: int
         :param dry: bool
-        :return: total fees for the whole rebalance
+        :return: total fees for the whole rebalance in msat
         """
 
         amt_msat = amt_sat * 1000
@@ -86,6 +55,7 @@ class Rebalancer(object):
 
             routes = self.router.get_routes_for_rebalancing(
                 channel_id_from, channel_id_to, amt_msat)
+
             if len(routes) == 0:
                 raise NoRouteError
             else:
@@ -101,9 +71,10 @@ class Rebalancer(object):
                 logger.info(f"   Channel is too expensive. "
                             f"Rate: {rate:.6f}, requested max rate: {self.max_effective_fee_rate:.6f}")
                 raise TooExpensive
+
             if r.total_fee_msat > budget_sat * 1000:
                 logger.info(f"   Channel is too expensive. "
-                            f"Fee: {r.total_fee_msat:.6f} msats, requested max fee: {budget_sat:.6f} msats")
+                            f"Fee: {r.total_fee_msat:.6f} msat, requested max fee: {budget_sat:.6f} msat")
                 raise TooExpensive
 
             if not dry:
@@ -118,27 +89,37 @@ class Rebalancer(object):
                 if result.payment_error:
                     # determine the channel/node that reported a failure
                     reporting_channel_id = self.node.handle_payment_error(result.payment_error)
+
                     if reporting_channel_id:
                         # determine the following channel that failed
-                        index_failed_channel = r.channel_hops.index(reporting_channel_id)
-                        failed_channel_id = r.channel_hops[index_failed_channel]
-
+                        try:
+                            index_failed_channel = r.channel_hops.index(reporting_channel_id)
+                            failed_channel_id = r.channel_hops[index_failed_channel]
+                        except ValueError:
+                            logger.error("Failed channel not even in list of channel hops (lnd issue?).")
+                            continue
+                        # check if a failed channel was our own, which should, in principle, not happen
                         if failed_channel_id in [channel_id_from, channel_id_to]:
-                            raise Exception(f"Own channel failed. Something is wrong. "
+                            raise Exception(f"Own channel failed. Something is wrong. This is likely due to a wrong "
+                                            f"accounting for the channel reserve and will be fixed in the future. Try"
+                                            f"with smaller absolute target."
                                             f"Failing channel: {failed_channel_id}")
 
+                        # determine the nodes involved in the channel
                         failed_channel_source = r.node_hops[index_failed_channel - 1]
                         failed_channel_target = r.node_hops[index_failed_channel]
                         logger.info(f"   Failed channel: {failed_channel_id}")
-                        logger.debug(f"   Failed channel between {failed_channel_source} and {failed_channel_target}")
-                        logger.debug(r.node_hops)
-                        logger.debug(r.channel_hops)
+                        logger.debug(f"   Failed channel between nodes {failed_channel_source}"
+                                     f" and {failed_channel_target}")
+                        logger.debug(f"    Node hops {r.node_hops}")
+                        logger.debug(f"    Channel hops {r.channel_hops}")
+
                         # remember the bad channel for next routing
                         self.router.channel_rater.add_bad_channel(
                             failed_channel_id, failed_channel_source, failed_channel_target)
 
-                    else:  # usually UnknownNextPeer
-                        # then add all the inner hops to the blacklist
+                    else:  # usually the case of UnknownNextPeer
+                        # add all the inner hops to the blacklist
                         logger.error("   Unknown next peer somewhere in route.")
                         inner_hops = r.channel_hops[1:-1]
                         for i_hop, hop in enumerate(inner_hops):
@@ -154,34 +135,75 @@ class Rebalancer(object):
             else:  # dry
                 raise DryRunException
 
-    def get_rebalance_candidates(self, direction):
+    def get_rebalance_candidates(self, channel_id, local_balance_change, allow_unbalancing=False, strategy=None):
         """
-        Determines channels, which can be used to rebalance a channel. The direction sets,
-        if the to be balanced channel has more inbound or outbound capacity.
+        Determines channels, which can be used to rebalance a channel. If the local_balance_change is negative,
+        the local balance of the to be balanced channel is tried to be reduced. This method determines channels
+        with which we can rebalance by ideally balancing also the counterparty. However, this is not always possible
+        so one can also specify to allow unbalancing until an unbalancedness of UNBALANCED_CHANNEL and no more.
+        One can also specify a strategy, which determines the order of channels of the rebalancing process.
 
-        :param direction: -1 / 1
+        :param channel_id: the channel id of the to be rebalanced channel
+        :param local_balance_change: amount by which the local balance of channel should change in sat
+        :param allow_unbalancing: bool
+        :param strategy: str,
+            None: By default, counterparty channels are sorted such that the ones unbalanced in the opposite direction
+                  are chosen first, such that they also get balanced. After them also the other channels, unbalanced in
+                  the non-ideal direction are tried (if allowed by allow_unbalancing).
+            'feerate': Channels are sorted by increasing peer fee rate.
+            'affordable': Channels are sorted by the absolute affordable amount.
         :return: list of channels
         """
+        rebalance_candidates = []
 
-        # filters all unbalanced channels
-        rebalance_candidates = [
-            c for c in self.channel_list
-            if -1.0 * direction * c['unbalancedness'] > _settings.UNBALANCED_CHANNEL
-        ]
+        # select the proper lower bound (allows for unbalancing a channel)
+        if allow_unbalancing:
+            lower_bound = -_settings.UNBALANCED_CHANNEL  # target is a bit into the non-ideal direction
+        else:
+            lower_bound = 0  # target is complete balancedness
+        # TODO: allow for complete depletion
 
-        # filter channels, which are already perfectly balanced
-        rebalance_candidates = [c for c in rebalance_candidates if not c['amt_to_balanced'] == 0]
+        # determine the direction, -1: channel is sending, 1: channel is receiving
+        direction = -math.copysign(1, local_balance_change)
 
-        # filters by max_effective_fee_rate
+        # logic to shift the bounds accordingly into the different rebalancing directions
+        for c in self.channel_list:
+            if direction * c['unbalancedness'] > lower_bound:
+                if allow_unbalancing:
+                    c['amt_affordable'] = int(
+                        c['amt_to_balanced'] + direction * _settings.UNBALANCED_CHANNEL * c['capacity'] / 2)
+                else:
+                    c['amt_affordable'] = c['amt_to_balanced']
+                rebalance_candidates.append(c)
+
+        # filter channels, which can't afford a rebalance
+        rebalance_candidates = [c for c in rebalance_candidates if not c['amt_affordable'] == 0]
+
+        # filters by max_effective_fee_rate, as this is the minimal fee rate to be paid
         rebalance_candidates = [
             c for c in rebalance_candidates
-            if self.effective_fee_rate(c['amt_to_balanced'], c['peer_base_fee'], c['peer_fee_rate'])
-            < self.max_effective_fee_rate
-        ]
+            if self.effective_fee_rate(c['amt_affordable'], c['peer_base_fee'], c['peer_fee_rate'])
+            < self.max_effective_fee_rate]
 
-        # TODO: make it possible to specify a sorting strategy
-        rebalance_candidates.sort(key=lambda x: x['amt_to_balanced'], reverse=True)
-        # rebalance_candidates.sort(key=lambda x: x['fees']['rate'])
+        # need to make sure we don't rebalance with the same channel
+        rebalance_candidates = [
+            c for c in rebalance_candidates if c['chan_id'] != channel_id]
+
+        # need to remove multiply connected nodes, if the counterparty channel should receive (can't control last hop)
+        if local_balance_change < 0:
+            rebalance_candidates = [
+                c for c in rebalance_candidates if not self.node_is_multiply_connected(c['remote_pubkey'])]
+
+        if strategy == 'most-affordable-first':
+            rebalance_candidates.sort(key=lambda x: direction * x['amt_affordable'], reverse=True)
+        elif strategy == 'lowest-feerate-first':
+            rebalance_candidates.sort(key=lambda x: x['peer_fee_rate'])
+        elif strategy == 'match-unbalanced':
+            rebalance_candidates.sort(key=lambda x: -direction * x['unbalancedness'])
+        else:
+            rebalance_candidates.sort(key=lambda x: direction * x['amt_to_balanced'], reverse=True)
+        # TODO: for each rebalance candidate calculate the shortest path with absolute fees and sort
+
         return rebalance_candidates
 
     @staticmethod
@@ -194,7 +216,6 @@ class Rebalancer(object):
         :param rate:
         :return: effective fee rate
         """
-
         amt_msat = amt_sat * 1000
         assert not (amt_msat == 0)
         rate = (base + rate * amt_msat / 1000000) / amt_msat
@@ -202,24 +223,26 @@ class Rebalancer(object):
 
     @staticmethod
     def print_rebalance_candidates(rebalance_candidates):
-        logger.debug(f"-------- Found {len(rebalance_candidates)} candidates for rebalancing --------")
+        logger.debug(f"-------- Description --------")
         logger.debug(
             "cid: channel id\n"
             "ub: unbalancedness (see --help)\n"
-            "atb: amount to be balanced [sats]\n"
-            "l: local balance [sats]\n"
-            "r: remote balance [sats]\n"
-            "bf: peer base fee [msats]\n"
+            "atb: amount to be balanced [sat]\n"
+            "aaf: amount affordable [sat]\n"
+            "l: local balance [sat]\n"
+            "r: remote balance [sat]\n"
+            "bf: peer base fee [msat]\n"
             "fr: peer fee rate\n"
             "a: alias"
         )
 
-        logger.debug(f"-------- Candidates --------")
+        logger.debug(f"-------- Candidates in order of rebalance attempts --------")
         for c in rebalance_candidates:
             logger.debug(
                 f"cid:{c['chan_id']} "
                 f"ub:{c['unbalancedness']: 4.2f} "
                 f"atb:{c['amt_to_balanced']: 9d} "
+                f"aaf:{c['amt_affordable']: 9d} "
                 f"l:{c['local_balance']: 9d} "
                 f"r:{c['remote_balance']: 9d} "
                 f"bf:{c['peer_base_fee']: 6d} "
@@ -228,7 +251,7 @@ class Rebalancer(object):
 
     def extract_channel_info(self, chan_id):
         """
-        Gets the channel info (policy, capacity, nodes) from the graph. Sometimes this could fail.
+        Gets the channel info (policy, capacity, nodes) from the graph.
         :param chan_id:
         :return: channel information
         """
@@ -241,10 +264,6 @@ class Rebalancer(object):
         return channel_info
 
     @staticmethod
-    def is_balanced(unbalancedness):
-        return abs(unbalancedness) < _settings.UNBALANCED_CHANNEL
-
-    @staticmethod
     def get_source_and_target_channels(channel_one, channel_two, rebalance_direction):
         if rebalance_direction < 0:
             source = channel_one
@@ -255,7 +274,77 @@ class Rebalancer(object):
 
         return source, target
 
-    def rebalance(self, channel_id, dry=False, chunksize=1.0):
+    @staticmethod
+    def maximal_local_balance_change(target, unbalanced_channel_info):
+        """
+        Tries to find out the amount to maximally send/receive given the relative target
+        and channel reserve constraints.
+
+        The target is expressed as a relative quantity between -1 and 1:
+        -1: channel has only local balance
+        0: 50:50 balanced
+        1: channel has only remote balance
+
+        :param target: positive or negative float, interpreted in terms of unbalancedness [-1...1]
+        :param unbalanced_channel_info: dict, information on the channel
+        :return: int: positive or negative amount in sat (encodes the decrease/increase in the local balance)
+        """
+        # both parties need to maintain a channel reserve of 1% according to BOLT 2
+        channel_reserve = int(0.01 * unbalanced_channel_info['capacity'])
+
+        if target:
+            commit_fee = 0
+            if unbalanced_channel_info['initiator']:  # a commit fee needs to be only respected by the channel initiator
+                commit_fee = unbalanced_channel_info['commit_fee']
+
+            # first naively calculate the local balance change to fulfill the requested target
+            local_balance_target = int(unbalanced_channel_info['capacity'] * 0.5 * (-target + 1.0) - commit_fee)
+            local_balance_change = local_balance_target - unbalanced_channel_info['local_balance']
+
+            # TODO: clarify exact definitions of dust and htlc_cost (somewhat guessing here)
+            # related: https://github.com/lightningnetwork/lnd/issues/1076
+            # https://github.com/lightningnetwork/lightning-rfc/blob/master/03-transactions.md#fees
+            dust = 700
+            htlc_weight = 172
+            number_htlcs = 2
+            htlc_cost = int(number_htlcs * htlc_weight * unbalanced_channel_info['fee_per_kw'] / 1000)
+            logger.debug(f">>> Assuming a dust limit of {dust} sat and an HTLC cost of {htlc_cost} sat.")
+
+            # we can only send the local balance less the channel reserve (if above the dust limit),
+            # less the cost to enforce the HTLC
+            can_send = max(0, unbalanced_channel_info['local_balance']
+                           - max(dust, channel_reserve) - htlc_cost - 1)
+
+            # we can only receive the remote balance less the channel reserve (if above the dust limit)
+            can_receive = max(0, unbalanced_channel_info['remote_balance']
+                              - max(dust, channel_reserve) - 1)
+
+            logger.debug(f">>> Channel can send {can_send} sat and receive {can_receive} sat.")
+
+            # check that we respect and enforce the channel reserve
+            if local_balance_change > 0 and abs(local_balance_change) > can_receive:
+                local_balance_change = can_receive
+            if local_balance_change < 0 and abs(local_balance_change) > can_send:
+                local_balance_change = -can_send
+
+            amt_target_original = int(local_balance_change)
+        else:
+            # just use the already calculated optimal amount for 50:50 balancedness
+            amt_target_original = unbalanced_channel_info['amt_to_balanced']
+
+        return amt_target_original
+
+    def node_is_multiply_connected(self, pub_key):
+        channels = 0
+        for c in self.channel_list:
+            if c['remote_pubkey'] == pub_key:
+                channels += 1
+        if channels > 1:
+            return True
+        else:
+            return False
+
+    def rebalance(self, channel_id, dry=False, chunksize=1.0, target=None, allow_unbalancing=False, strategy=None):
         """
         Automatically rebalances a selected channel with a fee cap of self.budget_sat and self.max_effective_fee_rate.
         Rebalancing candidates are selected among all channels which are unbalanced in the other direction.
@@ -271,9 +360,11 @@ class Rebalancer(object):
         :param channel_id:
         :param dry: bool: if set, then there's a dry run
         :param chunksize: float between 0 and 1
-        :return: fees for rebalancing
+        :param target: specifies unbalancedness after rebalancing
+        :param allow_unbalancing: bool, allows counterparty channels to get a little bit unbalanced
+        :param strategy: lets you select a strategy for rebalancing order
+        :return: int, fees in msat paid for rebalancing
         """
-
         if not (0.0 <= chunksize <= 1.0):
             raise ValueError("Chunk size must be between 0.0 and 1.0")
 
@@ -286,22 +377,49 @@ class Rebalancer(object):
 
         unbalanced_channel_info = self.extract_channel_info(channel_id)
 
-        # amount to balanced is the absolute amount the channel balance is off to be at 50:50
-        amt_target_original = unbalanced_channel_info['amt_to_balanced']
-        amt_target = int(amt_target_original)
-        # unbalancedness means -1: totally outbound, 0: balanced, 1: totally inbound
-        unbalancedness = unbalanced_channel_info['unbalancedness']
+        # if a target is given and it is set close to -1 or 1, then we need to think about the channel reserve
+        initial_local_balance_change = self.maximal_local_balance_change(target, unbalanced_channel_info)
 
-        if self.is_balanced(unbalancedness):
-            logger.info(f"Channel already balanced. Unbalancedness: {unbalancedness}")
+        if initial_local_balance_change == 0:
+            logger.info(f"Channel already balanced.")
             return None
 
-        logger.info(f">>> Amount required for the channel to be balanced is {int(amt_target_original)} sat.")
+        local_balance_change_left = initial_local_balance_change  # copy the original target
+        rebalance_direction = math.copysign(1, initial_local_balance_change)  # 1: receive, -1: send
 
-        rebalance_direction = (1, -1)[unbalancedness < 0]  # maps to the sign of unbalancedness
-        rebalance_candidates = self.get_rebalance_candidates(rebalance_direction)
+        logger.info(f">>> The channel status before rebalancing is lb:{unbalanced_channel_info['local_balance']} sat "
+                    f"rb:{unbalanced_channel_info['remote_balance']} sat "
+                    f"cap:{unbalanced_channel_info['capacity']} sat.")
+        logger.debug(f">>> Commit fee {unbalanced_channel_info['commit_fee']} sat."
+                     f" We opened channel: {unbalanced_channel_info['initiator']}."
+                     f" Channel reserve: {int(unbalanced_channel_info['capacity'] * 0.01)} sat.")
+        logger.debug(f">>> The change in local balance towards the requested target"
+                     f" (ub={target if target else 0.0:3.2f})"
+                     f" is {initial_local_balance_change} sat.")
+        commit_fee = 0
+        if unbalanced_channel_info['initiator']:
+            commit_fee = unbalanced_channel_info['commit_fee']
 
-        logger.info(f">>> There are {len(rebalance_candidates)} channels with which we can rebalance (look at logfile).")
+        expected_target = - 2 * ((unbalanced_channel_info['local_balance'] + initial_local_balance_change + commit_fee)
+                                 / float(unbalanced_channel_info['capacity']) - 0.5)
+        logger.info(f">>> Trying to change the local balance by {initial_local_balance_change} sat.\n"
+                    f"    The expected target is {expected_target:3.2f} (respecting channel reserve),"
+                    f" requested target is {0 if not target else target:3.2f}.")
+
+        if (initial_local_balance_change > 0
+                and self.node_is_multiply_connected(unbalanced_channel_info['remote_pubkey'])):
+            raise RebalanceFailure("Receiving rebalancing of multiply connected node channel not supported.\n"
+                                   "The reason is that the last hop (channel) can't be controlled by us.\n"
+                                   "See https://github.com/lightningnetwork/lnd/issues/2966 and \n"
+                                   "https://github.com/lightningnetwork/lightning-rfc/blob/master/"
+                                   "04-onion-routing.md#non-strict-forwarding.\n"
+                                   "Tip: keep only the best channel to the node and then rebalance.")
+
+
+        rebalance_candidates = self.get_rebalance_candidates(
+            channel_id, local_balance_change_left, allow_unbalancing=allow_unbalancing, strategy=strategy)
+
+        logger.info(f">>> There are {len(rebalance_candidates)} channels with which we can rebalance (look at logs).")
 
         self.print_rebalance_candidates(rebalance_candidates)
 
@@ -309,9 +427,9 @@ class Rebalancer(object):
         logger.info(f">>> NOTE: only individual rebalance requests are optimized for fees:\n"
                     f"    this means that there can be rebalances with less fees afterwards,\n"
                     f"    so take a look at the dry runs first, i.e. without the --reckless flag,\n"
-                    f"    and set --max-fee-sat and --max-fee-rate accordingly.")
+                    f"    and set --max-fee-sat and --max-fee-rate accordingly.\n"
+                    f"    You may also specify a rebalancing strategy by the --strategy flag.")
         logger.info(f">>> Rebalancing can take some time. Please be patient!\n")
-
 
         # create an invoice with a zero amount for all rebalance attempts (reduces number of invoices)
         invoice_r_hash = self.node.get_rebalance_invoice(
@@ -322,33 +440,36 @@ class Rebalancer(object):
         # loop over the rebalancing candidates
         for c in rebalance_candidates:
 
-            if 1.0 * amt_target / amt_target_original <= 0.1:
-                logger.info(f"Goal is reached. Rebalancing done. Total fees were {total_fees_msat} msats.")
-                break
-
             if total_fees_msat >= self.budget_sat * 1000:
                 raise RebalanceFailure("Fee budget exhausted")
 
             source_channel, target_channel = self.get_source_and_target_channels(
                 channel_id, c['chan_id'], rebalance_direction)
 
-            if amt_target_original > c['amt_to_balanced']:
-                amt = int(c['amt_to_balanced'] * chunksize)
+            if abs(local_balance_change_left) > abs(c['amt_affordable']):
+                amt = int(abs(c['amt_affordable']) * chunksize)
             else:
-                amt = int(amt_target_original * chunksize)
+                amt = int(local_balance_change_left * chunksize)
 
-            logger.info(f"-------- Rebalance from {source_channel} to {target_channel} with {amt} sats --------")
-            logger.info(f"Need to still rebalance {amt_target} sat to reach the goal of {amt_target_original} sat."
-                        f" Fees paid up to now: {total_fees_msat} msats.")
+            logger.info(f"-------- Rebalance from {source_channel} to {target_channel} with {amt} sat --------")
+            logger.info(f"Need to still rebalance {local_balance_change_left} sat to reach the goal"
+                        f" of {initial_local_balance_change} sat."
+                        f" Fees paid up to now: {total_fees_msat} msat.")
 
             # attempt the rebalance
             try:
                 # be up to date with the blockheight, otherwise could lead to cltv errors
                 self.node.update_blockheight()
                 total_fees_msat += self.rebalance_two_channels(
-                    source_channel, target_channel, amt, invoice_r_hash, self.budget_sat, dry=dry)
-                amt_target -= amt
-                invoice_r_hash = self.node.get_rebalance_invoice(memo=f"lndmanage: Rebalance of channel {channel_id}.")
+                    source_channel, target_channel, abs(amt), invoice_r_hash, self.budget_sat, dry=dry)
+                local_balance_change_left -= amt
+
+                if 1.0 * local_balance_change_left / initial_local_balance_change <= 0.1:
+                    logger.info(f"Goal is reached. Rebalancing done. Total fees were {total_fees_msat} msat.")
+                    break
+                else:
+                    invoice_r_hash = self.node.get_rebalance_invoice(
+                        memo=f"lndmanage: Rebalance of channel {channel_id}.")
             except NoRouteError:
                 logger.error("There was no route cheap enough or with enough capacity.\n")
             except DryRunException:


### PR DESCRIPTION
This is a major change of the rebalancer. It is now possible to specify a rebalancing target, i.e. what the unbalancedness should be after the rebalance. The target can be specified to be between [-1, 1], where 0 is completely balanced.
Edge cases can happen, when a channel should get depleted. Then the channel reserve has to be respected. This pull request tries to implement that, although not everything is perfectly clear, so this is an experimental feature.
A strategy can now be supplied, by which the order of rebalancing attempts is chosen.
With this pull request, we also restrict receiving rebalancing of channels of nodes which are multiply connected to us. The reason is that in the case, when we want to send out, we can't control, which channel on our side should receive and weird things can happen then.