### PR TITLE
listchannels: listchannels forwardings shows a bandwidth demand heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,21 +114,22 @@ fees       fees total [sats]
 f/w        fees per week [sats]
 ub         unbalancedness
 flow       flow direction (positive is outwards)
+bwd        bandwidth demand: capacity / max(mean_in, mean_out)
 r          rebalance required if marked with X
 cap        channel capacity [sats]
 in         total forwardings inwards [sats]
-imed       median forwarding inwards [sats]
+imean      mean forwarding inwards [sats]
 imax       largest forwarding inwards [sats]
 out        total forwardings outwards [sats]
-omed       median forwarding outwards [sats]
+omean      mean forwarding outwards [sats]
 omax       largest forwarding outwards [sats]
 a          alias
 
 -------- Channels --------
-       cid         nfwd   age  fees     f/w    ub  flow r      cap         in    imed    imax        out    omed    omax    a
-xxxxxxxxxxxxxxxxxx    6   103   907 106.950  0.30  1.00 X  6000000 |        0     nan     nan |  1935309   20000 1800902 | abc
-xxxxxxxxxxxxxxxxxx    3    82   300  35.374  0.74 -0.08    1000000 |   700008  700008  700008 |   600000  600000  600000 | def
-xxxxxxxxxxxxxxxxxx    4    32   216  25.461  0.38  0.42 X  6000000 |   993591  993591  993591 |  2450000  750000 1000000 | ghi
+       cid         nfwd   age  fees     f/w    ub  flow  bwd r      cap       in   imean    imax      out   omean    omax  a
+xxxxxxxxxxxxxxxxxx    6   103   907 106.950  0.30  1.00 0.00 X  6000000        0     nan     nan  1935309   20000 1800902 abc
+xxxxxxxxxxxxxxxxxx    3    82   300  35.374  0.74 -0.08 0.70    1000000   700008  700008  700008   600000  600000  600000 def
+xxxxxxxxxxxxxxxxxx    4    32   216  25.461  0.38  0.42 0.17 X  6000000   993591  993591  993591  2450000  750000 1000000 ghi
 ...
 ```
 

--- a/examples/example_node_info.py
+++ b/examples/example_node_info.py
@@ -1,5 +1,5 @@
 import _settings
-from lib.channels import print_channels_rebalance
+from lib.listchannels import print_channels_rebalance
 from lib.node import LndNode
 
 import logging.config

--- a/lib/forwardings.py
+++ b/lib/forwardings.py
@@ -9,6 +9,13 @@ logger.addHandler(logging.NullHandler())
 np.warnings.filterwarnings('ignore')
 
 
+def nan_to_zero(number):
+    if (number is np.nan or number != number):
+        return 0
+    else:
+        return number
+
+
 class ForwardingAnalyzer(object):
     """
     Analyzes forwardings for single channels.
@@ -168,11 +175,15 @@ def get_forwarding_statistics_channels(node, time_interval_start, time_interval_
     for c in channels:
         try:  # channel forwarding statistics exists
             channel_statistics = statistics[c['chan_id']]
+            c['bandwidth_demand'] = max(nan_to_zero(channel_statistics['mean_forwarding_in']),
+                                        nan_to_zero(channel_statistics['mean_forwarding_out'])) / c['capacity']
             c['fees_total'] = channel_statistics['fees_total']
             c['fees_total_per_week'] = channel_statistics['fees_total'] / (forwarding_analyzer.max_time_interval / 7)
             c['flow_direction'] = channel_statistics['flow_direction']
             c['median_forwarding_in'] = channel_statistics['median_forwarding_in']
             c['median_forwarding_out'] = channel_statistics['median_forwarding_out']
+            c['mean_forwarding_in'] = channel_statistics['mean_forwarding_in']
+            c['mean_forwarding_out'] = channel_statistics['mean_forwarding_out']
             c['number_forwardings'] = channel_statistics['number_forwardings']
             c['largest_forwarding_amount_in'] = channel_statistics['largest_forwarding_amount_in']
             c['largest_forwarding_amount_out'] = channel_statistics['largest_forwarding_amount_out']
@@ -186,11 +197,14 @@ def get_forwarding_statistics_channels(node, time_interval_start, time_interval_
                 c['rebalance_required'] = False
 
         except KeyError:  # no forwarding statistics on channel is available
+            c['bandwidth_demand'] = 0
             c['fees_total'] = 0
             c['fees_total_per_week'] = 0
             c['flow_direction'] = float('nan')
             c['median_forwarding_out'] = float('nan')
             c['median_forwarding_in'] = float('nan')
+            c['mean_forwarding_out'] = float('nan')
+            c['mean_forwarding_in'] = float('nan')
             c['number_forwardings'] = 0
             c['largest_forwarding_amount_in'] = float('nan')
             c['largest_forwarding_amount_out'] = float('nan')

--- a/lib/listchannels.py
+++ b/lib/listchannels.py
@@ -10,6 +10,7 @@ channel_abbrev = {
     'age': 'age',
     'alias': 'a',
     'amount_to_balanced': 'atb',
+    'bandwidth_demand': 'bwd',
     'capacity': 'cap',
     'chan_id': 'cid',
     'channel_point': 'cpt',
@@ -35,8 +36,10 @@ channel_abbrev = {
     'total_forwarding_out': 'out',
     'unbalancedness': 'ub',
     'median_forwarding_in': 'imed',
+    'mean_forwarding_in': 'imean',
     'largest_forwarding_amount_in': 'imax',
     'median_forwarding_out': 'omed',
+    'mean_forwarding_out': 'omean',
     'largest_forwarding_amount_out': 'omax',
 }
 
@@ -135,13 +138,14 @@ def print_channels_forwardings(node, time_interval_start, time_interval_end, sor
         f"{channel_abbrev['fees_total_per_week']:<10} fees per week [sats]\n"
         f"{channel_abbrev['unbalancedness']:<10} unbalancedness\n"
         f"{channel_abbrev['flow_direction']:<10} flow direction (positive is outwards)\n"
+        f"{channel_abbrev['bandwidth_demand']:<10} bandwidth demand: capacity / max(mean_in, mean_out)\n"
         f"{channel_abbrev['rebalance_required']:<10} rebalance required if marked with X\n"
         f"{channel_abbrev['capacity']:<10} channel capacity [sats]\n"
         f"{channel_abbrev['total_forwarding_in']:<10} total forwardings inwards [sats]\n"
-        f"{channel_abbrev['median_forwarding_in']:<10} median forwarding inwards [sats]\n"
+        f"{channel_abbrev['mean_forwarding_in']:<10} mean forwarding inwards [sats]\n"
         f"{channel_abbrev['largest_forwarding_amount_in']:<10} largest forwarding inwards [sats]\n"
         f"{channel_abbrev['total_forwarding_out']:<10} total forwardings outwards [sats]\n"
-        f"{channel_abbrev['median_forwarding_out']:<10} median forwarding outwards [sats]\n"
+        f"{channel_abbrev['mean_forwarding_out']:<10} mean forwarding outwards [sats]\n"
         f"{channel_abbrev['largest_forwarding_amount_out']:<10} largest forwarding outwards [sats]\n"
         f"{channel_abbrev['alias']:<10} alias\n"
     )
@@ -161,13 +165,14 @@ def print_channels_forwardings(node, time_interval_start, time_interval_end, sor
                 f"{channel_abbrev['fees_total_per_week']:>8}"
                 f"{channel_abbrev['unbalancedness']:>6}"
                 f"{channel_abbrev['flow_direction']:>6}"
+                f"{channel_abbrev['bandwidth_demand']:>5}"
                 f"{channel_abbrev['rebalance_required']:>2}"
                 f"{channel_abbrev['capacity']:>9}"
-                f"{channel_abbrev['total_forwarding_in']:>11}"
-                f"{channel_abbrev['median_forwarding_in']:>8}"
+                f"{channel_abbrev['total_forwarding_in']:>9}"
+                f"{channel_abbrev['mean_forwarding_in']:>8}"
                 f"{channel_abbrev['largest_forwarding_amount_in']:>8}"
-                f"{channel_abbrev['total_forwarding_out']:>11}"
-                f"{channel_abbrev['median_forwarding_out']:>8}"
+                f"{channel_abbrev['total_forwarding_out']:>9}"
+                f"{channel_abbrev['mean_forwarding_out']:>8}"
                 f"{channel_abbrev['largest_forwarding_amount_out']:>8}"
                 f"{channel_abbrev['alias']:^15}"
             )
@@ -179,14 +184,15 @@ def print_channels_forwardings(node, time_interval_start, time_interval_end, sor
             f"{c['fees_total_per_week'] / 1000:7.3f} "
             f"{c['unbalancedness']:5.2f} "
             f"{c['flow_direction']:5.2f} "
+            f"{c['bandwidth_demand']:3.2f} "
             f"{'X' if c['rebalance_required'] else ' '} "
             f"{c['capacity']:8.0f} "
-            f"| {c['total_forwarding_in']:8.0f} "
-            f"{c['median_forwarding_in']:7.0f} "
+            f"{c['total_forwarding_in']:8.0f} "
+            f"{c['mean_forwarding_in']:7.0f} "
             f"{c['largest_forwarding_amount_in']:7.0f} "
-            f"| {c['total_forwarding_out']:8.0f} "
-            f"{c['median_forwarding_out']:7.0f} "
-            f"{c['largest_forwarding_amount_out']:7.0f} | "
+            f"{c['total_forwarding_out']:8.0f} "
+            f"{c['mean_forwarding_out']:7.0f} "
+            f"{c['largest_forwarding_amount_out']:7.0f} "
             f"{c['alias'][:10] + '...' if len(c['alias']) > 10 else c['alias']} "
         )
 

--- a/lndmanage.py
+++ b/lndmanage.py
@@ -4,7 +4,7 @@ import _settings
 import time
 
 from lib.node import LndNode
-from lib.channels import print_channels_rebalance, print_channels_hygiene, print_channels_forwardings
+from lib.listchannels import print_channels_rebalance, print_channels_hygiene, print_channels_forwardings
 from lib.rebalance import Rebalancer
 from lib.exceptions import DryRunException, PaymentTimeOut, TooExpensive, RebalanceFailure
 


### PR DESCRIPTION
We transition to the mean incoming and outgoing amount of forwardings in ```listchannels forwardings``` as this reflects better the demand for larger channels as if the median was used.

A bandwidth demand is defined, which is
```max(mean(inward forwardings), mean(outgoing forwardings))/(channel capacity)```.

This way one can now easily see, if a channel has to be expanded in capacity.