### PR TITLE
node-recommendation: recommendation of nodes with historic forwardings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current feature list (use the ```--help``` flag for subcommands):
   * a target 'balancedness' can be specified (e.g. to empty the channel)
 * doing circular self-payments ```circle```
 * recommendation of nodes:
-  * find non-connected nodes with a history of successful forwardings ```recommend-node good-old```
+  * based on historic forwardings of closed channels: find nodes already interacted with ```recommend-nodes good-old```
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 
@@ -34,7 +34,7 @@ positional arguments:
                         subcommands with -h]
     rebalance           rebalance a channel
     circle              circular self-payment
-
+    recommend-nodes     recommends nodes [see also subcommands with -h]
 ```
 
 Rebalancing a channel

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Current feature list (use the ```--help``` flag for subcommands):
   * list channels for rebalancing ```listchannels rebalance```
   * list inactive channels for channel hygiene ```listchannels inactive```
   * list forwarding statistics for each channel ```listchannels forwardings```
-* rebalancing of channels ```rebalance```
+* rebalancing of channels ```rebalance```:
   * different strategies can be chosen
   * a target 'balancedness' can be specified (e.g. to empty the channel)
 * doing circular self-payments ```circle```
+* recommendation of nodes:
+  * find non-connected nodes with a history of successful forwardings ```recommend-node good-old```
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 

--- a/lib/rebalance.py
+++ b/lib/rebalance.py
@@ -166,7 +166,7 @@ class Rebalancer(object):
         direction = -math.copysign(1, local_balance_change)
 
         # logic to shift the bounds accordingly into the different rebalancing directions
-        for c in self.channel_list:
+        for k, c in self.channel_list.items():
             if direction * c['unbalancedness'] > lower_bound:
                 if allow_unbalancing:
                     c['amt_affordable'] = int(
@@ -255,7 +255,7 @@ class Rebalancer(object):
         :return: channel information
         """
         channel_info = None
-        for c in self.channel_list:
+        for k, c in self.channel_list.items():
             if c['chan_id'] == chan_id:
                 channel_info = c
         if channel_info is None:
@@ -340,7 +340,7 @@ class Rebalancer(object):
         :return: bool, true if number of channels to the node is larger than 1
         """
         channels = 0
-        for c in self.channel_list:
+        for k, c in self.channel_list.items():
             if c['remote_pubkey'] == pub_key:
                 channels += 1
         if channels > 1:
@@ -379,7 +379,7 @@ class Rebalancer(object):
         if dry:
             logger.info(f">>> This is a dry run, nothing to fear.")
 
-        unbalanced_channel_info = self.extract_channel_info(channel_id)
+        unbalanced_channel_info = self.channel_list[channel_id]
 
         # if a target is given and it is set close to -1 or 1, then we need to think about the channel reserve
         initial_local_balance_change = self.maximal_local_balance_change(target, unbalanced_channel_info)

--- a/lib/recommend_node.py
+++ b/lib/recommend_node.py
@@ -1,0 +1,135 @@
+from collections import OrderedDict
+import time
+
+import _settings
+
+from lib.forwardings import ForwardingAnalyzer
+from lib.listchannels import abbreviations, abbreviations_reverse
+
+import logging.config
+logging.config.dictConfig(_settings.logger_config)
+logger = logging.getLogger(__name__)
+
+
+class RecommendNode(object):
+    """
+    A class to recommend nodes to connect to.
+    """
+    def __init__(self, node, show_connected=False, show_addresses=False):
+        self.node = node
+        self.show_connected = show_connected
+        self.show_address = show_addresses
+
+    def good_old(self):
+        """
+        Gives back a list of nodes to which we already had a good relationship with historic forwardings.
+        :return: dict, nodes sorted by total amount forwarded
+        """
+        forwarding_analyzer = ForwardingAnalyzer(self.node)
+        forwarding_analyzer.initialize_forwarding_data(0, time.time())  # analyze all historic forwardings
+        nodes = forwarding_analyzer.get_forwarding_statistics_nodes()
+
+        if not self.show_connected:
+            nodes = self.exclude_connected_nodes(nodes)
+
+        nodes = self.add_metadata_and_remove_pruned(nodes)
+        return nodes
+
+    def add_metadata_and_remove_pruned(self, nodes):
+        """
+        Adds metadata as the number of channels, total capacity, ip address to the dict of nodes.
+
+        :param nodes: dict
+        :return: dict
+        """
+        nodes_new = {}
+        for k, n in nodes.items():
+            try:
+                node_new = {k: n for k, n in n.items()}
+                node_new['alias'] = self.node.network.node_alias(k)
+                number_channels = self.node.network.number_channels(k)
+                total_capacity = self.node.network.node_capacity(k)
+                node_new['number_channels'] = number_channels
+                if number_channels > 0:
+                    node_new['total_capacity'] = total_capacity
+                    node_new['capacity_per_channel'] = float(total_capacity) / number_channels
+                    node_new['address'] = self.node.network.node_address(k)
+                    nodes_new[k] = node_new
+            except KeyError:  # it was a pruned node if it is not found in the graph and it shouldn't be recommended
+                pass
+
+        return nodes_new
+
+    def exclude_connected_nodes(self, nodes):
+        """
+        Excludes already connected nodes from the nodes dict.
+        :param nodes: dict, keys are node pub keys
+        :return: dict
+        """
+        open_channels = self.node.get_open_channels()
+        connected_node_pubkeys = set()
+        filtered_nodes = OrderedDict()
+
+        for k, v in open_channels.items():
+            connected_node_pubkeys.add(v['remote_pubkey'])
+
+        for k, v in nodes.items():
+            if k not in connected_node_pubkeys:
+                filtered_nodes[k] = v
+
+        return filtered_nodes
+
+    def print_good_old(self, number_of_nodes=5, sort_by='tot'):
+        nodes = self.good_old()
+        if len(nodes) == 0:
+            logger.info(">>> Did not find historic recordings of forwardings, therefore cannot recommend any node.")
+        else:
+            sorted_nodes = OrderedDict(sorted(nodes.items(), key=lambda x: -x[1][abbreviations_reverse[sort_by]]))
+            logger.debug(f"Found {len(sorted_nodes)} nodes as good old nodes.")
+            logger.debug(f"Sorting by {sort_by}.")
+            logger.info("-------- Description --------")
+            logger.info(
+                f"{abbreviations['remote_pubkey']:<10} remote public key\n"
+                f"{abbreviations['total_forwarding']:<10} total forwarded amount [sat]\n"
+                f"{abbreviations['flow_direction']:<10} flow direction, value between [-1, 1], -1 is inwards\n"
+                f"{abbreviations['number_channels']:<10} number of channels\n"
+                f"{abbreviations['total_capacity']:<10} total capacity [ksat]\n"
+                f"{abbreviations['capacity_per_channel']:<10} capacity per channel [ksat]\n"
+                f"{abbreviations['alias']:<10} alias\n"
+            )
+            logger.info(f"-------- Nodes (limited to {number_of_nodes} nodes) --------")
+
+            logger.info(
+                f"{abbreviations['remote_pubkey']:^66}"
+                f"{abbreviations['total_forwarding']:>10}"
+                f"{abbreviations['flow_direction']:>6}"
+                f"{abbreviations['number_channels']:>6}"
+                f"{abbreviations['total_capacity']:>11}"
+                f"{abbreviations['capacity_per_channel']:>10}"
+                f"{abbreviations['alias']:>8}")
+            n = 0
+            for k, v in sorted_nodes.items():
+                n += 1
+                if n > number_of_nodes:
+                    break
+                logger.info(
+                    f"{k} "
+                    f"{v['total_forwarding']:9d} "
+                    f"{v['flow_direction']: 3.2f} "
+                    f"{v['number_channels']: 5.0f} "
+                    f"{v['total_capacity'] / 1000: 10.0f} "
+                    f"{v['capacity_per_channel'] / 1000: 9.0f} "
+                    f"{v['alias']}"
+                )
+                if self.show_address:
+                    if v['address']:
+                        logger.info('   ' + v['address'])
+                    else:
+                        logger.info('   no address available')
+
+
+if __name__ == '__main__':
+    from lib.node import LndNode
+    nd = LndNode()
+    rn = RecommendNode(nd)
+    rn.print_good_old()

--- a/lib/recommend_nodes.py
+++ b/lib/recommend_nodes.py
@@ -11,7 +11,7 @@ logging.config.dictConfig(_settings.logger_config)
 logger = logging.getLogger(__name__)
 
 
-class RecommendNode(object):
+class RecommendNodes(object):
     """
     A class to recommend nodes to connect to.
     """
@@ -131,5 +131,5 @@ class RecommendNode(object):
 if __name__ == '__main__':
     from lib.node import LndNode
     nd = LndNode()
-    rn = RecommendNode(nd)
+    rn = RecommendNodes(nd)
     rn.print_good_old()

--- a/lndmanage.py
+++ b/lndmanage.py
@@ -7,6 +7,7 @@ from lib.node import LndNode
 from lib.listchannels import print_channels_rebalance, print_channels_hygiene, print_channels_forwardings
 from lib.rebalance import Rebalancer
 from lib.exceptions import DryRunException, PaymentTimeOut, TooExpensive, RebalanceFailure
+from lib.recommend_node import RecommendNode
 
 
 def range_limited_float_type(arg):
@@ -27,106 +28,134 @@ def unbalanced_float(x):
     return x
 
 
-def parse_arguments():
-    # setup the command line parser
-    parser = argparse.ArgumentParser(
-        prog='lndmanage.py',
-        description='Lightning network daemon channel management tool.')
-    parser.add_argument('--loglevel', default='INFO', choices=['INFO', 'DEBUG'])
-    subparsers = parser.add_subparsers(dest='cmd')
+class Parser(object):
+    def __init__(self):
+        # setup the command line parser
+        self.parser = argparse.ArgumentParser(
+            prog='lndmanage.py',
+            description='Lightning network daemon channel management tool.')
+        self.parser.add_argument('--loglevel', default='INFO', choices=['INFO', 'DEBUG'])
+        subparsers = self.parser.add_subparsers(dest='cmd')
 
-    # cmd: status
-    parser_status = subparsers.add_parser(
-        'status', help='display node status',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        # cmd: status
+        self.parser_status = subparsers.add_parser(
+            'status', help='display node status',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    # cmd: listchannels
-    parser_listchannels = subparsers.add_parser(
-        'listchannels', help='lists channels with extended information [see also subcommands with -h]',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    listchannels_subparsers = parser_listchannels.add_subparsers(dest='subcmd')
+        # cmd: listchannels
+        self.parser_listchannels = subparsers.add_parser(
+            'listchannels', help='lists channels with extended information [see also subcommands with -h]',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        listchannels_subparsers = self.parser_listchannels.add_subparsers(dest='subcmd')
 
-    # subcmd: listchannels rebalance
-    parser_listchannels_rebalance = listchannels_subparsers.add_parser(
-        'rebalance', help='displays unbalanced channels')
-    parser_listchannels_rebalance.add_argument(
-        '--unbalancedness', type=float,
-        default=0.5,
-        help='Unbalancedness is a way to express how balanced a channel is, '
-             'a value between [-1, 1] (a perfectly balanced channel has a value of 0). '
-             'The flag excludes channels with an absolute unbalancedness smaller than UNBALANCEDNESS.')
+        # subcmd: listchannels rebalance
+        parser_listchannels_rebalance = listchannels_subparsers.add_parser(
+            'rebalance', help='displays unbalanced channels')
+        parser_listchannels_rebalance.add_argument(
+            '--unbalancedness', type=float,
+            default=0.5,
+            help='Unbalancedness is a way to express how balanced a channel is, '
+                 'a value between [-1, 1] (a perfectly balanced channel has a value of 0). '
+                 'The flag excludes channels with an absolute unbalancedness smaller than UNBALANCEDNESS.')
 
-    # subcmd: listchannels inactive
-    parser_listchannels_inactive = listchannels_subparsers.add_parser(
-        'inactive', help="displays inactive channels")
+        # subcmd: listchannels inactive
+        parser_listchannels_inactive = listchannels_subparsers.add_parser(
+            'inactive', help="displays inactive channels")
 
-    # subcmd: listchannels forwardings
-    parser_listchannels_forwardings = listchannels_subparsers.add_parser(
-        'forwardings', help="displays channels with forwarding information")
-    parser_listchannels_forwardings.add_argument(
-        '--sort-by', default='f/w', type=str, help='sort by column (look at description)')
-    parser_listchannels_forwardings.add_argument(
-        '--from-days-ago', default=365, type=int, help='time interval start (days ago)')
-    parser_listchannels_forwardings.add_argument(
-        '--to-days-ago', default=0, type=int, help='time interval end (days ago)')
+        # subcmd: listchannels forwardings
+        parser_listchannels_forwardings = listchannels_subparsers.add_parser(
+            'forwardings', help="displays channels with forwarding information")
+        parser_listchannels_forwardings.add_argument(
+            '--sort-by', default='f/w', type=str, help='sort by column (look at description)')
+        parser_listchannels_forwardings.add_argument(
+            '--from-days-ago', default=365, type=int, help='time interval start (days ago)')
+        parser_listchannels_forwardings.add_argument(
+            '--to-days-ago', default=0, type=int, help='time interval end (days ago)')
 
-    # cmd: rebalance
-    parser_rebalance = subparsers.add_parser(
-        'rebalance', help='rebalance a channel', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_rebalance.add_argument('channel', type=int, help='channel_id')
-    parser_rebalance.add_argument(
-        '--max-fee-sat', type=int, default=20, help='Sets the maximal fees in satoshis to be paid.')
-    parser_rebalance.add_argument(
-        '--chunksize', type=float, default=1.0, help='Specifies if the individual rebalance attempts should be '
-                                                     'split into smaller relative amounts. This increases success'
-                                                     ' rates, but also increases costs!')
-    parser_rebalance.add_argument(
-        '--max-fee-rate', type=range_limited_float_type, default=5E-5,
-        help='Sets the maximal effective fee rate to be paid.'
-             ' The effective fee rate is defined by (base_fee + amt * fee_rate) / amt.')
-    parser_rebalance.add_argument(
-        '--reckless', help='Execute action in the network.', action='store_true')
-    parser_rebalance.add_argument(
-        '--allow-unbalancing', help=f'Allow channels to get an unbalancedness up to +-{_settings.UNBALANCED_CHANNEL}.',
-        action='store_true')
-    parser_rebalance.add_argument(
-        '--target', help=f'This feature is still experimental!'
-        f' The unbalancedness target is between [-1, 1]. A target of -1 leads to a maximal local balance, a target of 0'
-        f' to a 50:50 balanced channel and a target of 1 to a maximal remote balance. Default is a target of 0.',
-        type=unbalanced_float, default=None)
-    rebalancing_strategies = ['most-affordable-first', 'lowest-feerate-first', 'match-unbalanced']
-    parser_rebalance.add_argument(
-        '--strategy',
-        help=f'Rebalancing strategy.',
-        choices=rebalancing_strategies, type=str, default=None)
+        # cmd: rebalance
+        self.parser_rebalance = subparsers.add_parser(
+            'rebalance', help='rebalance a channel', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        self.parser_rebalance.add_argument('channel', type=int, help='channel_id')
+        self.parser_rebalance.add_argument(
+            '--max-fee-sat', type=int, default=20, help='Sets the maximal fees in satoshis to be paid.')
+        self.parser_rebalance.add_argument(
+            '--chunksize', type=float, default=1.0, help='Specifies if the individual rebalance attempts should be '
+                                                         'split into smaller relative amounts. This increases success'
+                                                         ' rates, but also increases costs!')
+        self.parser_rebalance.add_argument(
+            '--max-fee-rate', type=range_limited_float_type, default=5E-5,
+            help='Sets the maximal effective fee rate to be paid.'
+                 ' The effective fee rate is defined by (base_fee + amt * fee_rate) / amt.')
+        self.parser_rebalance.add_argument(
+            '--reckless', help='Execute action in the network.', action='store_true')
+        self.parser_rebalance.add_argument(
+            '--allow-unbalancing', help=f'Allow channels to get an unbalancedness up to +-{_settings.UNBALANCED_CHANNEL}.',
+            action='store_true')
+        self.parser_rebalance.add_argument(
+            '--target', help=f'This feature is still experimental!'
+            f' The unbalancedness target is between [-1, 1]. A target of -1 leads to a maximal local balance, a target of 0'
+            f' to a 50:50 balanced channel and a target of 1 to a maximal remote balance. Default is a target of 0.',
+            type=unbalanced_float, default=None)
+        rebalancing_strategies = ['most-affordable-first', 'lowest-feerate-first', 'match-unbalanced']
+        self.parser_rebalance.add_argument(
+            '--strategy',
+            help=f'Rebalancing strategy.',
+            choices=rebalancing_strategies, type=str, default=None)
 
-    # cmd: circle
-    parser_circle = subparsers.add_parser(
-        'circle', help='circular self-payment', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_circle.add_argument('channel_from', type=int, help='channel_from')
-    parser_circle.add_argument('channel_to', type=int, help='channel_from')
-    parser_circle.add_argument('amt_sats', type=int, help='amount in satoshis')
-    parser_circle.add_argument(
-        '--max-fee-sat', type=int, default=20, help='Sets the maximal fees in satoshis to be paid.')
-    parser_circle.add_argument(
-        '--max-fee-rate', type=range_limited_float_type, default=5E-5,
-        help='Sets the maximal effective fee rate to be paid.'
-             ' The effective fee rate is defined by (base_fee + amt * fee_rate) / amt.')
-    parser_circle.add_argument(
-        '--reckless', help='Execute action in the network.', action='store_true')
+        # cmd: circle
+        self.parser_circle = subparsers.add_parser(
+            'circle', help='circular self-payment', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        self.parser_circle.add_argument('channel_from', type=int, help='channel_from')
+        self.parser_circle.add_argument('channel_to', type=int, help='channel_from')
+        self.parser_circle.add_argument('amt_sats', type=int, help='amount in satoshis')
+        self.parser_circle.add_argument(
+            '--max-fee-sat', type=int, default=20, help='Sets the maximal fees in satoshis to be paid.')
+        self.parser_circle.add_argument(
+            '--max-fee-rate', type=range_limited_float_type, default=5E-5,
+            help='Sets the maximal effective fee rate to be paid.'
+                 ' The effective fee rate is defined by (base_fee + amt * fee_rate) / amt.')
+        self.parser_circle.add_argument(
+            '--reckless', help='Execute action in the network.', action='store_true')
 
-    return parser.parse_args()
+        # cmd: recommend-node
+        self.parser_recommend_node = subparsers.add_parser(
+            'recommend-node', help='recommends a node [see also subcommands with -h]',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        self.parser_recommend_node.add_argument(
+            '--show-connected', action='store_true', default=False, help='specifies if already connected nodes should'
+                                                                         ' be removed from list')
+        self.parser_recommend_node.add_argument(
+            '--show-addresses', action='store_true', default=False, help='specifies if node addresses should be shown')
+        parser_recommend_node_subparsers = self.parser_recommend_node.add_subparsers(dest='subcmd')
+
+        # subcmd: recommend-node good-old
+        parser_recommend_node_good_old = parser_recommend_node_subparsers.add_parser(
+            'good-old', help='shows nodes already interacted with but no active channels')
+        parser_recommend_node_good_old.add_argument(
+            '--nnodes', default=20, type=int, help='sets the number of nodes displayed')
+        parser_recommend_node_good_old.add_argument(
+            '--sort-by', default='tot', type=str, help="sort by column [abbreviation, e.g. 'tot']")
+
+    def parse_arguments(self):
+        return self.parser.parse_args()
 
 
 def main():
-    args = parse_arguments()
+    parser = Parser()
+    args = parser.parse_arguments()
     # print(args)
+
+    if args.cmd is None:
+        parser.parser.print_help()
+        return 0
+
     # program execution
     if args.loglevel:
         # update the loglevel of the stdout handler to the user choice
         logger.handlers[0].setLevel(args.loglevel)
 
     node = LndNode()
+
     if args.cmd == 'status':
         node.print_status()
 
@@ -168,6 +197,16 @@ def main():
             logger.error("Payment failed. This is likely due to a too low default --max-fee-rate.")
         except PaymentTimeOut:
             logger.error("Payment failed because the payment timed out. This is an unresolved issue.")
+
+    elif args.cmd == 'recommend-node':
+
+        if not args.subcmd:
+            parser.parser_recommend_node.print_help()
+            return 0
+
+        recommend_node = RecommendNode(node, show_connected=args.show_connected, show_addresses=args.show_addresses)
+        if args.subcmd == 'good-old':
+            recommend_node.print_good_old(number_of_nodes=args.nnodes, sort_by=args.sort_by)
 
 
 if __name__ == '__main__':

--- a/lndmanage.py
+++ b/lndmanage.py
@@ -7,7 +7,7 @@ from lib.node import LndNode
 from lib.listchannels import print_channels_rebalance, print_channels_hygiene, print_channels_forwardings
 from lib.rebalance import Rebalancer
 from lib.exceptions import DryRunException, PaymentTimeOut, TooExpensive, RebalanceFailure
-from lib.recommend_node import RecommendNode
+from lib.recommend_nodes import RecommendNodes
 
 
 def range_limited_float_type(arg):
@@ -118,22 +118,22 @@ class Parser(object):
             '--reckless', help='Execute action in the network.', action='store_true')
 
         # cmd: recommend-node
-        self.parser_recommend_node = subparsers.add_parser(
-            'recommend-node', help='recommends a node [see also subcommands with -h]',
+        self.parser_recommend_nodes = subparsers.add_parser(
+            'recommend-nodes', help='recommends nodes [see also subcommands with -h]',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        self.parser_recommend_node.add_argument(
+        self.parser_recommend_nodes.add_argument(
             '--show-connected', action='store_true', default=False, help='specifies if already connected nodes should'
                                                                          ' be removed from list')
-        self.parser_recommend_node.add_argument(
+        self.parser_recommend_nodes.add_argument(
             '--show-addresses', action='store_true', default=False, help='specifies if node addresses should be shown')
-        parser_recommend_node_subparsers = self.parser_recommend_node.add_subparsers(dest='subcmd')
+        parser_recommend_nodes_subparsers = self.parser_recommend_nodes.add_subparsers(dest='subcmd')
 
         # subcmd: recommend-node good-old
-        parser_recommend_node_good_old = parser_recommend_node_subparsers.add_parser(
+        parser_recommend_nodes_good_old = parser_recommend_nodes_subparsers.add_parser(
             'good-old', help='shows nodes already interacted with but no active channels')
-        parser_recommend_node_good_old.add_argument(
+        parser_recommend_nodes_good_old.add_argument(
             '--nnodes', default=20, type=int, help='sets the number of nodes displayed')
-        parser_recommend_node_good_old.add_argument(
+        parser_recommend_nodes_good_old.add_argument(
             '--sort-by', default='tot', type=str, help="sort by column [abbreviation, e.g. 'tot']")
 
     def parse_arguments(self):
@@ -198,15 +198,15 @@ def main():
         except PaymentTimeOut:
             logger.error("Payment failed because the payment timed out. This is an unresolved issue.")
 
-    elif args.cmd == 'recommend-node':
+    elif args.cmd == 'recommend-nodes':
 
         if not args.subcmd:
-            parser.parser_recommend_node.print_help()
+            parser.parser_recommend_nodes.print_help()
             return 0
 
-        recommend_node = RecommendNode(node, show_connected=args.show_connected, show_addresses=args.show_addresses)
+        recommend_nodes = RecommendNodes(node, show_connected=args.show_connected, show_addresses=args.show_addresses)
         if args.subcmd == 'good-old':
-            recommend_node.print_good_old(number_of_nodes=args.nnodes, sort_by=args.sort_by)
+            recommend_nodes.print_good_old(number_of_nodes=args.nnodes, sort_by=args.sort_by)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request adds functionality for recommending nodes to the node operator based on certain heuristics.

It starts with implementing a recommendation for nodes with which the managed node had already historic forwardings. The subcommand is called ```recommend-nodes good-old```.