### PR TITLE
recommend-nodes: based on flow analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Current feature list (use the ```--help``` flag for subcommands):
 * doing circular self-payments ```circle```
 * recommendation of nodes:
   * based on historic forwardings of closed channels: find nodes already interacted with ```recommend-nodes good-old```
+  * based on flow-analysis: find nodes payments are likely forwarded to ```recommend-nodes flow-analysis```
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 

--- a/lib/network.py
+++ b/lib/network.py
@@ -146,6 +146,26 @@ class Network(object):
     def node_address(self, node_pub_key):
         return self.graph.node[node_pub_key]['address']
 
+    def neighbors(self, node_pub_key):
+        """
+        Finds all the node pub keys of nearest neighbor nodes
+        :param node_pub_key:  str
+        :return: node_pub_key: str
+        """
+        neighbors = nx.neighbors(self.graph, node_pub_key)
+        for n in neighbors:
+            yield n
+
+    def second_neighbors(self, node_pub_key):
+        """
+        Finds all the node pub keys of second nearest neighbor nodes (non-unique)
+        :param node_pub_key: str
+        :return: node_pub_key: str
+        """
+        for neighbor_list in [self.graph.neighbors(n) for n in self.graph.neighbors(node_pub_key)]:
+            for n in neighbor_list:
+                yield n
+
 
 if __name__ == '__main__':
     import logging.config

--- a/lib/recommend_nodes.py
+++ b/lib/recommend_nodes.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from collections import OrderedDict
 import time
 
@@ -35,16 +36,32 @@ class RecommendNodes(object):
         nodes = self.add_metadata_and_remove_pruned(nodes)
         return nodes
 
+    def flow_analysis(self, out_direction=True, last_forwardings_to_analyze=200):
+        """
+        Does a flow analysis and suggests nodes which have demand for inbound liquidity.
+        :param out_direction: bool, if True outward flowing nodes are displayed
+        :param last_forwardings_to_analyze: int, number of forwardings in analysis
+        :return: nodes dict with metadata
+        """
+        forwarding_analyzer = ForwardingAnalyzer(self.node)
+        forwarding_analyzer.initialize_forwarding_data(0, time.time())  # analyze all historic forwardings
+        nodes_in, nodes_out = forwarding_analyzer.simple_flow_analysis(last_forwardings_to_analyze)
+        raw_nodes = nodes_out if out_direction else nodes_in
+        if not self.show_connected:
+            raw_nodes = self.exclude_connected_nodes(raw_nodes)
+        nodes = self.add_metadata_and_remove_pruned(raw_nodes)
+        return nodes
+
     def add_metadata_and_remove_pruned(self, nodes):
         """
         Adds metadata as the number of channels, total capacity, ip address to the dict of nodes.
-
         :param nodes: dict
         :return: dict
         """
         nodes_new = {}
         for k, n in nodes.items():
             try:
+                # copy all the entries
                 node_new = {k: n for k, n in n.items()}
                 node_new['alias'] = self.node.network.node_alias(k)
                 number_channels = self.node.network.number_channels(k)
@@ -66,6 +83,7 @@ class RecommendNodes(object):
         :param nodes: dict, keys are node pub keys
         :return: dict
         """
+        logger.debug("Filtering nodes which are not connected to us.")
         open_channels = self.node.get_open_channels()
         connected_node_pubkeys = set()
         filtered_nodes = OrderedDict()
@@ -76,8 +94,18 @@ class RecommendNodes(object):
         for k, v in nodes.items():
             if k not in connected_node_pubkeys:
                 filtered_nodes[k] = v
+        print(len(filtered_nodes.keys()))
 
         return filtered_nodes
+
+    def print_flow_analysis(self, out_direction=True, number_of_nodes=5, forwarding_events=200):
+        nodes = self.flow_analysis(out_direction, last_forwardings_to_analyze=forwarding_events)
+        if len(nodes) == 0:
+            logger.info(">>> Did not find historic recordings of forwardings, therefore cannot recommend any node.")
+        else:
+            sorted_nodes = OrderedDict(sorted(nodes.items(), key=lambda x: -x[1]['weight']))
+            logger.debug(f"Found {len(sorted_nodes)} nodes in flow analysis.")
+            self.print_nodes_flow_analysis(sorted_nodes, number_of_nodes)
 
     def print_good_old(self, number_of_nodes=5, sort_by='tot'):
         nodes = self.good_old()
@@ -87,49 +115,85 @@ class RecommendNodes(object):
             sorted_nodes = OrderedDict(sorted(nodes.items(), key=lambda x: -x[1][abbreviations_reverse[sort_by]]))
             logger.debug(f"Found {len(sorted_nodes)} nodes as good old nodes.")
             logger.debug(f"Sorting by {sort_by}.")
-            logger.info("-------- Description --------")
-            logger.info(
-                f"{abbreviations['remote_pubkey']:<10} remote public key\n"
-                f"{abbreviations['total_forwarding']:<10} total forwarded amount [sat]\n"
-                f"{abbreviations['flow_direction']:<10} flow direction, value between [-1, 1], -1 is inwards\n"
-                f"{abbreviations['number_channels']:<10} number of channels\n"
-                f"{abbreviations['total_capacity']:<10} total capacity [ksat]\n"
-                f"{abbreviations['capacity_per_channel']:<10} capacity per channel [ksat]\n"
-                f"{abbreviations['alias']:<10} alias\n"
-            )
-            logger.info(f"-------- Nodes (limited to {number_of_nodes} nodes) --------")
+            self.print_nodes_good_old(sorted_nodes, number_of_nodes)
 
+    # TODO: unite the print command, don't repeat
+    def print_nodes_flow_analysis(self, nodes, number_of_nodes):
+        logger.info("-------- Description --------")
+        logger.info(
+            f"{abbreviations['remote_pubkey']:<10} remote public key\n"
+            f"{abbreviations['number_channels']:<10} number of channels\n"
+            f"{abbreviations['total_capacity']:<10} total capacity [ksat]\n"
+            f"{abbreviations['capacity_per_channel']:<10} capacity per channel [ksat]\n"
+            f"{abbreviations['alias']:<10} alias\n"
+        )
+        logger.info(f"-------- Nodes (limited to {number_of_nodes} nodes) --------")
+        logger.info(
+            f"{abbreviations['remote_pubkey']:^66}"
+            f"{abbreviations['number_channels']:>6}"
+            f"{abbreviations['total_capacity']:>11}"
+            f"{abbreviations['capacity_per_channel']:>10}"
+            f"{abbreviations['alias']:>8}")
+        n = 0
+        for k, v in nodes.items():
+            n += 1
+            if n > number_of_nodes:
+                break
             logger.info(
-                f"{abbreviations['remote_pubkey']:^66}"
-                f"{abbreviations['total_forwarding']:>10}"
-                f"{abbreviations['flow_direction']:>6}"
-                f"{abbreviations['number_channels']:>6}"
-                f"{abbreviations['total_capacity']:>11}"
-                f"{abbreviations['capacity_per_channel']:>10}"
-                f"{abbreviations['alias']:>8}")
-            n = 0
-            for k, v in sorted_nodes.items():
-                n += 1
-                if n > number_of_nodes:
-                    break
-                logger.info(
-                    f"{k} "
-                    f"{v['total_forwarding']:9d} "
-                    f"{v['flow_direction']: 3.2f} "
-                    f"{v['number_channels']: 5.0f} "
-                    f"{v['total_capacity'] / 1000: 10.0f} "
-                    f"{v['capacity_per_channel'] / 1000: 9.0f} "
-                    f"{v['alias']}"
-                )
-                if self.show_address:
-                    if v['address']:
-                        logger.info('   ' + v['address'])
-                    else:
-                        logger.info('   no address available')
+                f"{k} "
+                f"{v['number_channels']: 5.0f} "
+                f"{v['total_capacity'] / 1000: 10.0f} "
+                f"{v['capacity_per_channel'] / 1000: 9.0f} "
+                f"{v['alias']}"
+            )
+            if self.show_address:
+                if v['address']:
+                    logger.info('   ' + v['address'])
+                else:
+                    logger.info('   no address available')
+
+    def print_nodes_good_old(self, nodes, number_of_nodes):
+        logger.info("-------- Description --------")
+        logger.info(
+            f"{abbreviations['remote_pubkey']:<10} remote public key\n"
+            f"{abbreviations['total_forwarding']:<10} total forwarded amount [sat]\n"
+            f"{abbreviations['flow_direction']:<10} flow direction, value between [-1, 1], -1 is inwards\n"
+            f"{abbreviations['number_channels']:<10} number of channels\n"
+            f"{abbreviations['total_capacity']:<10} total capacity [ksat]\n"
+            f"{abbreviations['capacity_per_channel']:<10} capacity per channel [ksat]\n"
+            f"{abbreviations['alias']:<10} alias\n"
+        )
+        logger.info(f"-------- Nodes (limited to {number_of_nodes} nodes) --------")
+        logger.info(
+            f"{abbreviations['remote_pubkey']:^66}"
+            f"{abbreviations['total_forwarding']:>10}"
+            f"{abbreviations['flow_direction']:>6}"
+            f"{abbreviations['number_channels']:>6}"
+            f"{abbreviations['total_capacity']:>11}"
+            f"{abbreviations['capacity_per_channel']:>10}"
+            f"{abbreviations['alias']:>8}")
+        n = 0
+        for k, v in nodes.items():
+            n += 1
+            if n > number_of_nodes:
+                break
+            logger.info(
+                f"{k} "
+                f"{v['total_forwarding']:9d} "
+                f"{v['flow_direction']: 3.2f} "
+                f"{v['number_channels']: 5.0f} "
+                f"{v['total_capacity'] / 1000: 10.0f} "
+                f"{v['capacity_per_channel'] / 1000: 9.0f} "
+                f"{v['alias']}"
+            )
+            if self.show_address:
+                if v['address']:
+                    logger.info('   ' + v['address'])
+                else:
+                    logger.info('   no address available')
 
 
 if __name__ == '__main__':
     from lib.node import LndNode
     nd = LndNode()
     rn = RecommendNodes(nd)
-    rn.print_good_old()


### PR DESCRIPTION
Implements a probability based forwarding analysis. The goal is to find nodes which have a demand for inbound liquidity. The flow analysis is carried out in the following way:

For each forwarding event, we have an incoming node and an outgoing node.

* Take the incoming node and determine its nearest neighbors.
* Take these nearest neighbors and determine their nearest neighbors.
* This makes up a list of nodes (where nodes can appear multiple times), where the payment could have originated in.
* For each appearance, accumulate a weight (1/avg degree of network) for the nearest neighbors and (1/(avg degree of network)^2) for the next nearest neighbors of the incoming node, but cap the weight by an upper bound of 1.
* Do the same thing for the outgoing node.
* There are two sets now, with probability weights.
* From the outgoing set, subtract the incoming set, giving a new set with also negative weights.

To get the nodes where payments were flowing to, take only the nodes with positive weights. Normalize the weights. These probabilites can be accumulated for all forwardings, weighting them for example with the forwarding fee, the forwarding amount, or just without weighting.

Because the weights were capped, large routing nodes easily accumulate a weight equal to 1 in both, outward and inward directions and these will cancel out. In this way large routing nodes are avoided to appear in the final list.

Improvements:
* Take path probability into account (routing fees, channel activity, capacity)