### PR TITLE
recommend-nodes: based on a node file/url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@ lndmanage is a command line tool for advanced channel management of an [`LND`](h
 
 Current feature list (use the ```--help``` flag for subcommands):
 
-* __advanced node summary ```status```__
-* __compact ```listchannels``` commands:__
-  * list channels for rebalancing ```listchannels rebalance```
-  * list inactive channels for channel hygiene ```listchannels inactive```
-  * list forwarding statistics for each channel ```listchannels forwardings```
-* __rebalancing of channels ```rebalance```:__
+* __```status``` advanced node summary__
+* __informative ```listchannels``` commands:__
+  * ```listchannels rebalance```: list channels for rebalancing
+  * ```listchannels inactive```: list inactive channels for channel hygiene 
+  * ```listchannels forwardings```: list forwarding statistics for each channel 
+* __```rebalance``` rebalancing of channels:__
   * different strategies can be chosen
   * a target 'balancedness' can be specified (e.g. to empty the channel)
-* __doing circular self-payments ```circle```__
-* __recommendation of nodes: ```recommend-nodes```__
-  * based on historic forwardings of closed channels: find nodes already interacted with ```recommend-nodes good-old```
-  * based on a flow analysis: find nodes payments are likely forwarded to ```recommend-nodes flow-analysis```
-  * based on a node file: parses a url/file for node public keys and suggests nodes to connect to for a good connection ```recommend-nodes nodefile```
+* __```circle``` doing circular self-payments__
+* __```recommend-nodes```: recommendation of nodes:__
+  * ```recommend-nodes good-old```: based on historic forwardings of closed channels: find nodes already interacted with
+  * ```recommend-nodes flow-analysis```: based on a flow analysis: find nodes payments are likely forwarded to
+  * ```recommend-nodes nodefile```: based on a node file: parses a url/file for node public keys and suggests nodes to connect to for a good connection
+    (defaults to [lightning networkstores](http://lightningnetworkstores.com))
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@ lndmanage is a command line tool for advanced channel management of an [`LND`](h
 
 Current feature list (use the ```--help``` flag for subcommands):
 
-* advanced node summary ```status```
-* compact ```listchannels``` commands:
+* __advanced node summary ```status```__
+* __compact ```listchannels``` commands:__
   * list channels for rebalancing ```listchannels rebalance```
   * list inactive channels for channel hygiene ```listchannels inactive```
   * list forwarding statistics for each channel ```listchannels forwardings```
-* rebalancing of channels ```rebalance```:
+* __rebalancing of channels ```rebalance```:__
   * different strategies can be chosen
   * a target 'balancedness' can be specified (e.g. to empty the channel)
-* doing circular self-payments ```circle```
-* recommendation of nodes:
+* __doing circular self-payments ```circle```__
+* __recommendation of nodes: ```recommend-nodes```__
   * based on historic forwardings of closed channels: find nodes already interacted with ```recommend-nodes good-old```
-  * based on flow-analysis: find nodes payments are likely forwarded to ```recommend-nodes flow-analysis```
+  * based on a flow analysis: find nodes payments are likely forwarded to ```recommend-nodes flow-analysis```
+  * based on a node file: parses a url/file for node public keys and suggests nodes to connect to for a good connection ```recommend-nodes nodefile```
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ lndmanage is a command line tool for advanced channel management of an [`LND`](h
 Current feature list (use the ```--help``` flag for subcommands):
 
 * __```status``` advanced node summary__
-* __informative ```listchannels``` commands:__
-  * ```listchannels rebalance```: list channels for rebalancing
-  * ```listchannels inactive```: list inactive channels for channel hygiene 
-  * ```listchannels forwardings```: list forwarding statistics for each channel 
+* __```listchannels``` channel listing commands:__
+  * ```listchannels rebalance``` list channels for rebalancing
+  * ```listchannels inactive``` list inactive channels for channel hygiene 
+  * ```listchannels forwardings``` list forwarding statistics for each channel 
 * __```rebalance``` rebalancing of channels:__
   * different strategies can be chosen
   * a target 'balancedness' can be specified (e.g. to empty the channel)
 * __```circle``` doing circular self-payments__
-* __```recommend-nodes```: recommendation of nodes:__
-  * ```recommend-nodes good-old```: based on historic forwardings of closed channels: find nodes already interacted with
-  * ```recommend-nodes flow-analysis```: based on a flow analysis: find nodes payments are likely forwarded to
-  * ```recommend-nodes nodefile```: based on a node file: parses a url/file for node public keys and suggests nodes to connect to for a good connection
-    (defaults to [lightning networkstores](http://lightningnetworkstores.com))
+* __```recommend-nodes``` recommendation of nodes:__
+  * ```recommend-nodes good-old``` based on historic forwardings of closed channels: find nodes already interacted with
+  * ```recommend-nodes flow-analysis``` based on fowarding flow analysis: find nodes payments are likely forwarded to
+  * ```recommend-nodes nodefile``` based on a node file: parses a url/file for node public keys and suggests nodes to connect to for a good connection
+    (defaults to the list of [lightning networkstores](http://lightningnetworkstores.com))
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 

--- a/_settings.py
+++ b/_settings.py
@@ -25,6 +25,7 @@ MIN_REL_CHANNEL_CAPACITY = 0.75
 # -------- network analysis --------
 # a user typically has a low number of channels, this number
 NUMBER_CHANNELS_DEFINING_USER_NODE = 3
+NUMBER_CHANNELS_DEFINING_HUB = 200
 
 # -------- rebalancing --------
 # in terms of unbalancedness

--- a/lib/network_info.py
+++ b/lib/network_info.py
@@ -147,6 +147,21 @@ class NetworkAnalysis(object):
 
         return nx.single_source_shortest_path_length(self.node.network.graph, node_pub_key, cutoff=n)
 
+    def secondary_hops_added(self, node_pub_key):
+        """
+        Determines the number of secondary hops added if connected to the node.
+        :param node_pub_key: str
+        :return: int
+        """
+        potential_new_second_neighbors = set(nx.all_neighbors(self.node.network.graph, node_pub_key))
+        # print('pot new', potential_new_second_neighbors)
+        current_close_neighbors = set(self.get_nodes_n_hops_away(self.node.pub_key, 2).keys())
+        # print('curr close', current_close_neighbors)
+        new_second_neighbors = potential_new_second_neighbors.difference(current_close_neighbors)
+        # print('new sec', new_second_neighbors)
+        # print(len(new_second_neighbors))
+        return len(new_second_neighbors)
+
     def find_nodes_giving_most_secondary_hops(self, node_pub_key, results=10):
         """
         Which node should be added in order to reach the most other nodes with two hops?

--- a/lib/recommend_nodes.py
+++ b/lib/recommend_nodes.py
@@ -1,15 +1,76 @@
-from itertools import islice
-from collections import OrderedDict
 import time
+import re
+from collections import OrderedDict
+import urllib.request
+from urllib.error import HTTPError
 
 import _settings
 
 from lib.forwardings import ForwardingAnalyzer
-from lib.listchannels import abbreviations, abbreviations_reverse
 
 import logging.config
 logging.config.dictConfig(_settings.logger_config)
 logger = logging.getLogger(__name__)
+
+# define printing shortcuts, alignments, and cutoffs
+print_node_format = {
+    'alias': {
+        'dict_key': 'alias',
+        'description': 'alias',
+        'width': 20,
+        'format': '<30.29',
+        'align': '^',
+    },
+    'con': {
+        'dict_key': 'connections',
+        'description': 'connections with nodes in list',
+        'width': 6,
+        'format': '6.0f',
+        'align': '>',
+    },
+    'cpc': {
+        'dict_key': 'capacity_per_channel',
+        'description': 'capacity per channel [sat]',
+        'width': 10,
+        'format': '10.0f',
+        'align': '>',
+    },
+    'flow': {
+        'dict_key': 'flow_direction',
+        'description': 'flow_direction',
+        'width': 6,
+        'format': '6.2f',
+        'align': '>',
+    },
+    'nchan': {
+        'dict_key': 'number_channels',
+        'description': 'number of channels',
+        'width': 6,
+        'format': '6.0f',
+        'align': '>',
+    },
+    'rpk': {
+        'dict_key': 'remote_pubkey',
+        'description': 'remote public key',
+        'width': 66,
+        'format': '<66',
+        'align': '^',
+    },
+    'cap': {
+        'dict_key': 'total_capacity',
+        'description': 'total capacity [sat]',
+        'width': 10,
+        'format': '10.0f',
+        'align': '>',
+    },
+    'tot': {
+        'dict_key': 'total_forwarding',
+        'description': 'total forwarded [sat]',
+        'width': 9,
+        'format': '9d',
+        'align': '>',
+    },
+}
 
 
 class RecommendNodes(object):
@@ -29,10 +90,8 @@ class RecommendNodes(object):
         forwarding_analyzer = ForwardingAnalyzer(self.node)
         forwarding_analyzer.initialize_forwarding_data(0, time.time())  # analyze all historic forwardings
         nodes = forwarding_analyzer.get_forwarding_statistics_nodes()
-
         if not self.show_connected:
             nodes = self.exclude_connected_nodes(nodes)
-
         nodes = self.add_metadata_and_remove_pruned(nodes)
         return nodes
 
@@ -52,18 +111,100 @@ class RecommendNodes(object):
         nodes = self.add_metadata_and_remove_pruned(raw_nodes)
         return nodes
 
-    def add_metadata_and_remove_pruned(self, nodes):
+    def nodefile(self, source, distributing_nodes=False, exclude_hubs=True):
         """
-        Adds metadata as the number of channels, total capacity, ip address to the dict of nodes.
+        Parses a file/url (source) for node public keys and displays additional info.
+        If distributing_nodes is set to True, nodes which are well connected to the nodes in the nodefile are displayed.
+        Big hubs can be excluded by exclude_hubs.
+        :param source: str
+        :param distributing_nodes: bool
+        :param exclude_hubs: bool
+        """
+        source_found = False
+        text = None
+
+        # try first to find a web source behind source
+        try:
+            response = urllib.request.urlopen(source)
+            data = response.read()
+            text = data.decode('utf-8')
+            logger.info("Found a web source for the node list.")
+            source_found = True
+
+        except HTTPError as e:
+            logger.error("Something is not OK with your url.")
+            logger.debug(e)
+            return
+
+        except ValueError as e:
+            logger.warning("Entered source was not a url.")
+            logger.warning(e)
+
+        # if it was not a web source, try if it is a file
+        if not source_found:
+            try:
+                with open(source, 'r') as file:
+                    text = file.read()
+                logger.info("Found a file source for the node list.")
+                source_found = True
+            except FileNotFoundError as e:
+                logger.exception(e)
+
+        if not source_found:
+            raise FileNotFoundError(f"Didn't find anything under the source you provided: {source}")
+
+        # match the node public keys
+        pattern = re.compile("[a-z0-9]{66}")
+        nodes = re.finditer(pattern, text)
+
+        # create an empty dict for nodes, connections is the number of connections to the target nodes
+        nodes = {n.group(): {'connections': 0} for n in nodes}
+
+        # instead of analyzing the nodes extracted from the data source, we can look at their neighbors
+        # these neighbors can be seen as nodes, which distribute our capital to the target nodes
+        if distributing_nodes:
+            logger.info("Determining nodes that are well connected to the nodes from the node file.")
+
+            # it makes sense to exclude large hubs in the search, because everybody is already connected to them
+            if exclude_hubs:  # we exclude hubs in the neighbor analysis
+                nodes_list = [n for n in nodes.keys()
+                              if self.node.network.number_channels(n) < _settings.NUMBER_CHANNELS_DEFINING_HUB]
+            else:
+                nodes_list = nodes.keys()
+
+            # we also want to avoid to count the nodes we are already connected to with blacklist_nodes
+            blacklist_nodes = list(self.node.network.neighbors(self.node.pub_key))
+
+            node_neighbors_list = self.node.network.nodes_in_neighborhood_of_nodes(nodes_list, blacklist_nodes)
+            # set the number of connections to target nodes in the node dictionary
+            nodes = {n[0]: {'connections': n[1]} for n in node_neighbors_list}
+
+        nodes = self.add_metadata_and_remove_pruned(nodes, exclude_hubs)
+
+        if not self.show_connected:
+            nodes = self.exclude_connected_nodes(nodes)
+
+        return nodes
+
+    def add_metadata_and_remove_pruned(self, nodes, exclude_hubs=False):
+        """
+        Adds metadata like the number of channels, total capacity, ip address to the dict of nodes. If exclude_hubs is
+        set to True, big nodes will be removed from nodes.
         :param nodes: dict
+        :param exclude_hubs: bool
         :return: dict
         """
         nodes_new = {}
-        for k, n in nodes.items():
+        number_nodes = len(nodes.keys())
+        logger.info(f"Found {number_nodes} nodes for node recommendation.")
+        if exclude_hubs:
+            logger.info(f"Excluding hubs (defined by number of channels > {_settings.NUMBER_CHANNELS_DEFINING_HUB}).")
+        for counter, (k, n) in enumerate(nodes.items()):
             try:
                 # copy all the entries
                 node_new = {k: n for k, n in n.items()}
                 node_new['alias'] = self.node.network.node_alias(k)
+
                 number_channels = self.node.network.number_channels(k)
                 total_capacity = self.node.network.node_capacity(k)
                 node_new['number_channels'] = number_channels
@@ -71,7 +212,11 @@ class RecommendNodes(object):
                     node_new['total_capacity'] = total_capacity
                     node_new['capacity_per_channel'] = float(total_capacity) / number_channels
                     node_new['address'] = self.node.network.node_address(k)
-                    nodes_new[k] = node_new
+                    if exclude_hubs:
+                        if node_new['number_channels'] < _settings.NUMBER_CHANNELS_DEFINING_HUB:
+                            nodes_new[k] = node_new
+                    else:
+                        nodes_new[k] = node_new
             except KeyError:  # it was a pruned node if it is not found in the graph and it shouldn't be recommended
                 pass
 
@@ -94,98 +239,71 @@ class RecommendNodes(object):
         for k, v in nodes.items():
             if k not in connected_node_pubkeys:
                 filtered_nodes[k] = v
-        print(len(filtered_nodes.keys()))
 
         return filtered_nodes
 
-    def print_flow_analysis(self, out_direction=True, number_of_nodes=5, forwarding_events=200):
+    def print_flow_analysis(self, out_direction=True, number_of_nodes=20, forwarding_events=200):
         nodes = self.flow_analysis(out_direction, last_forwardings_to_analyze=forwarding_events)
         if len(nodes) == 0:
             logger.info(">>> Did not find historic recordings of forwardings, therefore cannot recommend any node.")
         else:
             sorted_nodes = OrderedDict(sorted(nodes.items(), key=lambda x: -x[1]['weight']))
             logger.debug(f"Found {len(sorted_nodes)} nodes in flow analysis.")
-            self.print_nodes_flow_analysis(sorted_nodes, number_of_nodes)
+            self.print_nodes(nodes, number_of_nodes, 'rpk,nchan,cap,cpc,alias')
 
-    def print_good_old(self, number_of_nodes=5, sort_by='tot'):
+    def print_good_old(self, number_of_nodes=20, sort_by='tot'):
         nodes = self.good_old()
         if len(nodes) == 0:
             logger.info(">>> Did not find historic recordings of forwardings, therefore cannot recommend any node.")
         else:
-            sorted_nodes = OrderedDict(sorted(nodes.items(), key=lambda x: -x[1][abbreviations_reverse[sort_by]]))
+            sorted_nodes = OrderedDict(sorted(nodes.items(),
+                                              key=lambda x: -x[1][print_node_format[sort_by]['dict_key']]))
             logger.debug(f"Found {len(sorted_nodes)} nodes as good old nodes.")
-            logger.debug(f"Sorting by {sort_by}.")
-            self.print_nodes_good_old(sorted_nodes, number_of_nodes)
+            logger.debug(f"Sorting nodes by {sort_by}.")
+            self.print_nodes(sorted_nodes, number_of_nodes, 'rpk,tot,flow,nchan,cap,cpc,alias')
 
-    # TODO: unite the print command, don't repeat
-    def print_nodes_flow_analysis(self, nodes, number_of_nodes):
-        logger.info("-------- Description --------")
-        logger.info(
-            f"{abbreviations['remote_pubkey']:<10} remote public key\n"
-            f"{abbreviations['number_channels']:<10} number of channels\n"
-            f"{abbreviations['total_capacity']:<10} total capacity [ksat]\n"
-            f"{abbreviations['capacity_per_channel']:<10} capacity per channel [ksat]\n"
-            f"{abbreviations['alias']:<10} alias\n"
-        )
-        logger.info(f"-------- Nodes (limited to {number_of_nodes} nodes) --------")
-        logger.info(
-            f"{abbreviations['remote_pubkey']:^66}"
-            f"{abbreviations['number_channels']:>6}"
-            f"{abbreviations['total_capacity']:>11}"
-            f"{abbreviations['capacity_per_channel']:>10}"
-            f"{abbreviations['alias']:>8}")
-        n = 0
-        for k, v in nodes.items():
-            n += 1
-            if n > number_of_nodes:
-                break
-            logger.info(
-                f"{k} "
-                f"{v['number_channels']: 5.0f} "
-                f"{v['total_capacity'] / 1000: 10.0f} "
-                f"{v['capacity_per_channel'] / 1000: 9.0f} "
-                f"{v['alias']}"
-            )
-            if self.show_address:
-                if v['address']:
-                    logger.info('   ' + v['address'])
-                else:
-                    logger.info('   no address available')
+    def print_nodefile(self, source, distributing_nodes, number_of_nodes=20, sort_by='cap'):
+        nodes = self.nodefile(source, distributing_nodes)
+        if len(nodes) == 0:
+            logger.info("Did not find any nodes in the file/url provided.")
+        else:
+            logger.info(f"Showing nodes from source {source}.")
+            sorted_nodes = OrderedDict(sorted(nodes.items(),
+                                              key=lambda x: -x[1][print_node_format[sort_by]['dict_key']]))
+            logger.debug(f"Found {len(sorted_nodes)} nodes as good old nodes.")
+            logger.debug(f"Sorting nodes by {sort_by}.")
+            self.print_nodes(sorted_nodes, number_of_nodes, 'rpk,con,nchan,cap,cpc,alias')
 
-    def print_nodes_good_old(self, nodes, number_of_nodes):
+    def print_nodes(self, nodes, number_of_nodes, columns):
+        """
+        General purpose printing function for flexible node tables.
+        Colums is a string, which includes the order and items of columns with a comma delimiter like so:
+        columns = "rpk,nchan,cap,cpc,a"
+        :param nodes: dict
+        :param number_of_nodes: int
+        :param columns: str
+        """
         logger.info("-------- Description --------")
-        logger.info(
-            f"{abbreviations['remote_pubkey']:<10} remote public key\n"
-            f"{abbreviations['total_forwarding']:<10} total forwarded amount [sat]\n"
-            f"{abbreviations['flow_direction']:<10} flow direction, value between [-1, 1], -1 is inwards\n"
-            f"{abbreviations['number_channels']:<10} number of channels\n"
-            f"{abbreviations['total_capacity']:<10} total capacity [ksat]\n"
-            f"{abbreviations['capacity_per_channel']:<10} capacity per channel [ksat]\n"
-            f"{abbreviations['alias']:<10} alias\n"
-        )
+        columns = columns.split(',')
+        for c in columns:
+            logger.info(f"{c:<10} {print_node_format[c]['description']}")
         logger.info(f"-------- Nodes (limited to {number_of_nodes} nodes) --------")
-        logger.info(
-            f"{abbreviations['remote_pubkey']:^66}"
-            f"{abbreviations['total_forwarding']:>10}"
-            f"{abbreviations['flow_direction']:>6}"
-            f"{abbreviations['number_channels']:>6}"
-            f"{abbreviations['total_capacity']:>11}"
-            f"{abbreviations['capacity_per_channel']:>10}"
-            f"{abbreviations['alias']:>8}")
-        n = 0
-        for k, v in nodes.items():
-            n += 1
-            if n > number_of_nodes:
+
+        # prepare the column header
+        column_header_list = [f"{c:{print_node_format[c]['align']}{print_node_format[c]['width']}}" for c in columns]
+        column_header = " ".join(column_header_list)
+        logger.info(column_header)
+
+        for ik, (k, v) in enumerate(nodes.items()):
+            if ik > number_of_nodes:
                 break
-            logger.info(
-                f"{k} "
-                f"{v['total_forwarding']:9d} "
-                f"{v['flow_direction']: 3.2f} "
-                f"{v['number_channels']: 5.0f} "
-                f"{v['total_capacity'] / 1000: 10.0f} "
-                f"{v['capacity_per_channel'] / 1000: 9.0f} "
-                f"{v['alias']}"
-            )
+            # print each row in a formated way specified in the print_node dictionary
+            row = [f"{v[print_node_format[c]['dict_key']]:{print_node_format[c]['format']}}"
+                   for c in columns if c != 'rpk']
+            row_string = " ".join(row)
+            row_string = k + " " + row_string
+            logger.info(row_string)
+
             if self.show_address:
                 if v['address']:
                     logger.info('   ' + v['address'])

--- a/lndmanage.py
+++ b/lndmanage.py
@@ -153,6 +153,22 @@ class Parser(object):
             '--inwarding-nodes', action='store_true',
             help='if True, inwarding nodes are displayed instead of outwarding')
 
+        # subcmd: recommend-node nodefile
+        parser_recommend_nodes_nodefile = parser_recommend_nodes_subparsers.add_parser(
+            'nodefile', help='recommends nodes from a given file/url',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser_recommend_nodes_nodefile.add_argument(
+            '--nnodes', default=20, type=int, help='sets the number of nodes displayed')
+        parser_recommend_nodes_nodefile.add_argument(
+            '--source', type=str,
+            default='https://github.com/lightningnetworkstores/lightningnetworkstores.github.io/raw/master/sites.json',
+            help='url/file to be analyzed')
+        parser_recommend_nodes_nodefile.add_argument(
+            '--distributing-nodes', action='store_true',
+            help='if True, distributing nodes are displayed instead of the bare nodes')
+        parser_recommend_nodes_nodefile.add_argument(
+            '--sort-by', default='cpc', type=str, help="sort by column [abbreviation, e.g. 'nchan']")
+
     def parse_arguments(self):
         return self.parser.parse_args()
 
@@ -227,6 +243,9 @@ def main():
         elif args.subcmd == 'flow-analysis':
             recommend_nodes.print_flow_analysis(out_direction=(not args.inwarding_nodes),
                                                 number_of_nodes=args.nnodes, forwarding_events=args.forwarding_events)
+        elif args.subcmd == 'nodefile':
+            recommend_nodes.print_nodefile(args.source, distributing_nodes=args.distributing_nodes,
+                                           number_of_nodes=args.nnodes, sort_by=args.sort_by)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements a method to suggest nodes, which are given by a file/url. The format of the file/url can be flexible, it only needs to contain public node keys that are separated in some way. The parsing is done with regular expressions for public keys.
The keys extracted from the node file are then analyzed and displayed. By default, the url points to the list of lightningnetworkstores.
There exists also an option to find nodes that are well connected to the nodes in the file, which are acting as sort of "distributing intermediary hubs".