### PR TITLE
Recommend nodes: based on channel openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ Current feature list (use the ```--help``` flag for subcommands):
   * a target 'balancedness' can be specified (e.g. to empty the channel)
 * __```circle``` doing circular self-payments__
 * __```recommend-nodes``` recommendation of nodes:__
-  * ```recommend-nodes good-old``` based on historic forwardings of closed channels: find nodes already interacted with
-  * ```recommend-nodes flow-analysis``` based on fowarding flow analysis: find nodes payments are likely forwarded to
-  * ```recommend-nodes nodefile``` based on a node file: parses a url/file for node public keys and suggests nodes to connect to for a good connection
-    (defaults to the list of [lightning networkstores](http://lightningnetworkstores.com))
+  * ```recommend-nodes good-old``` based on historic forwardings of closed channels:
+  find nodes already interacted with
+  * ```recommend-nodes flow-analysis``` based on fowarding flow analysis:
+  find nodes payments are likely forwarded to
+  * ```recommend-nodes nodefile``` based on a node file:
+  parses a url/file for node public keys and suggests nodes to connect to for a good connection 
+  (defaults to the list of [lightning networkstores](http://lightningnetworkstores.com))
+  * ```recommend-nodes channel-openings``` based on recent channel openings in the network:
+  find nodes which show increased recent channel opening activity 
 
 **DISCLAIMER: This is BETA software, so please be careful (All actions are executed as a dry run unless you call lndmanage with the ```--reckless``` flag though). No warranty is given.**
 

--- a/lib/network_info.py
+++ b/lib/network_info.py
@@ -1,6 +1,11 @@
+from collections import defaultdict
+
+import numpy as np
 import networkx as nx
 
 import _settings
+
+from lib.ln_utilities import convert_channel_id_to_short_channel_id
 
 import logging
 logger = logging.getLogger(__name__)
@@ -11,10 +16,13 @@ class NetworkAnalysis(object):
     """
     Class for network analysis.
 
-    :param node: :class:`lib.node.LndNode`
     """
 
     def __init__(self, node):
+        """
+        :param node: :class:`lib.node.LndNode`
+        """
+
         self.node = node
         self.nodes_info = self.nodes_information()
 
@@ -39,7 +47,7 @@ class NetworkAnalysis(object):
         Finds node_count nodes in the graph with the largest amount of bitcoin assigned in their channels.
 
         :param node_count: int
-        :return: list of nodes sorted by cacpacity
+        :return: list of nodes sorted by capacity
         """
 
         nodes_and_capacity = []
@@ -150,6 +158,7 @@ class NetworkAnalysis(object):
     def secondary_hops_added(self, node_pub_key):
         """
         Determines the number of secondary hops added if connected to the node.
+
         :param node_pub_key: str
         :return: int
         """
@@ -196,6 +205,89 @@ class NetworkAnalysis(object):
         logger.info("Finding all nodes, which when connected would give n new nodes reachable with two hops.")
         for node, number_neighbors in nodes:
             logger.info(f"Node: {node} - new neighbors: {number_neighbors}")
+
+    def determine_channel_openings(self, from_days_ago):
+        """
+        Determines all channel openings in the last `from_days_ago` days and creates a dictionary of nodes involved.
+
+        The dictionary values contain tuples of channel creation height and capacity of the channels that were opened.
+
+        :param from_days_ago: int
+        :return: dict, keys: node public keys, values: (block height, capacity)
+        """
+
+        logger.info(f"Determining channel openings in the last {from_days_ago} days (excluding already closed ones).")
+        # retrieve all channels in the network
+        all_channels_list = self.node.network.edges.keys()
+
+        # make sure the channels are sorted by age, oldest first
+        all_channels_list = sorted(all_channels_list)
+
+        # determine blockheight from where to start the analysis
+        blockheight_start = self.node.blockheight - from_days_ago * 24 * 6  # we have about six blocks per hour
+
+        # take only youngest channels
+        channels_filtered_and_creation_time = []
+        for cid in all_channels_list:
+            height = convert_channel_id_to_short_channel_id(cid)[0]
+            if height > blockheight_start:
+                channels_filtered_and_creation_time.append((cid, height))
+        logger.info(f"In the last {from_days_ago} days, there were at least {len(channels_filtered_and_creation_time)} "
+                    f"channel openings.")
+
+        # analyze the openings and assign tuples of (creation height, channel capacity) to nodes
+        channel_openings_per_node_dict = defaultdict(list)
+        for c, height in channels_filtered_and_creation_time:
+            edge = self.node.network.edges[c]
+            channel_openings_per_node_dict[edge['node1_pub']].append((height, edge['capacity']))
+            channel_openings_per_node_dict[edge['node2_pub']].append((height, edge['capacity']))
+
+        return channel_openings_per_node_dict
+
+    def calculate_channel_opening_statistics(self, from_days_ago, exclude_openings_less_than=5):
+        """
+        Calculates basic channel opening statistics for each node.
+
+        :param from_days_ago: int
+        :param exclude_openings_less_than: int, nodes with smaller channel openings than this are excluded
+        :return: dict, keys: nodes, values: serveral heuristics
+        """
+
+        openings_per_node_dict = self.determine_channel_openings(from_days_ago)
+        opening_statistics_per_node = {}
+
+        for n, nv in openings_per_node_dict.items():
+            # convert opening characteristics (heights and capacities) to lists
+            heights = [opening[0] for opening in nv]
+            capacities = [opening[1] for opening in nv]
+
+            # calculate the blockheight differences between successive channel openings (tells about frequency)
+            delta_heights = np.diff(heights)
+
+            # calculate median and average differences of channel openings (median can give hints on bursts of openings)
+            median_opening_time = np.median(delta_heights)
+            average_opening_time = np.mean(delta_heights)
+
+            # other interesting quantities
+            openings = len(capacities)
+            openings_total_capacity = sum(capacities)
+            openings_average_capacity = float(openings_total_capacity) / openings
+            node_total_capacity = self.node.network.node_capacity(n)
+            node_number_channels = self.node.network.number_channels(n)
+
+            # put all the data in a dictionary, which can then be handled by the node recommendation class
+            if openings > exclude_openings_less_than:
+                opening_statistics_per_node[n] = {
+                    'opening_median_time': median_opening_time,
+                    'opening_average_time': average_opening_time,
+                    'openings_average_capacity': openings_average_capacity / 1E8,  # in btc
+                    'openings': openings,
+                    'openings_total_capacity': openings_total_capacity / 1E8,  # in btc
+                    'relative_openings': float(openings) / node_number_channels,
+                    'relative_total_capacity': float(openings_total_capacity) / node_total_capacity,  # ksat
+                }
+
+        return opening_statistics_per_node
 
 
 if __name__ == '__main__':

--- a/lib/recommend_nodes.py
+++ b/lib/recommend_nodes.py
@@ -46,7 +46,7 @@ print_node_format = {
     },
     'cpc': {
         'dict_key': 'capacity_per_channel',
-        'description': 'capacity per channel [sat]',
+        'description': 'capacity per channel [btc]',
         'width': 10,
         'format': '1.8f',
         'align': '>',
@@ -109,7 +109,7 @@ print_node_format = {
     },
     'opencap': {
         'dict_key': 'openings_total_capacity',
-        'description': 'total capacity of channel openings in timeframe [ksat/time]',
+        'description': 'total capacity of channel openings in timeframe [btc/time]',
         'width': 7,
         'format': '7.3f',
         'align': '>',
@@ -123,7 +123,7 @@ print_node_format = {
     },
     'openavgcap': {
         'dict_key': 'openings_average_capacity',
-        'description': 'average channel capacity of channel openings in timeframe [ksat/time]',
+        'description': 'average channel capacity of channel openings in timeframe [btc/time]',
         'width': 11,
         'format': '11.8f',
         'align': '>',

--- a/lib/recommend_nodes.py
+++ b/lib/recommend_nodes.py
@@ -1,12 +1,14 @@
 import time
 import re
 from collections import OrderedDict
+
 import urllib.request
 from urllib.error import HTTPError
 
 import _settings
 
 from lib.forwardings import ForwardingAnalyzer
+from lib.network_info import NetworkAnalysis
 
 import logging.config
 logging.config.dictConfig(_settings.logger_config)
@@ -14,12 +16,26 @@ logger = logging.getLogger(__name__)
 
 # define printing shortcuts, alignments, and cutoffs
 print_node_format = {
+    'age': {
+        'dict_key': 'age_days',
+        'description': 'node age [days]',
+        'width': 5,
+        'format': '5.0f',
+        'align': '>',
+    },
     'alias': {
         'dict_key': 'alias',
         'description': 'alias',
         'width': 20,
         'format': '<30.29',
         'align': '^',
+    },
+    'cap': {
+        'dict_key': 'total_capacity',
+        'description': 'total capacity [btc]',
+        'width': 7,
+        'format': '7.3f',
+        'align': '>',
     },
     'con': {
         'dict_key': 'connections',
@@ -32,7 +48,7 @@ print_node_format = {
         'dict_key': 'capacity_per_channel',
         'description': 'capacity per channel [sat]',
         'width': 10,
-        'format': '10.0f',
+        'format': '1.8f',
         'align': '>',
     },
     'flow': {
@@ -42,11 +58,74 @@ print_node_format = {
         'format': '6.2f',
         'align': '>',
     },
+    'mburst': {
+        'dict_key': 'metric_burst',
+        'description': 'bursty old nodes',
+        'width': 8,
+        'format': '8.3f',
+        'align': '>',
+    },
+    'msteady': {
+        'dict_key': 'metric_steady',
+        'description': 'steady nodes with lots of capacity opening',
+        'width': 8,
+        'format': '8.3f',
+        'align': '>',
+    },
     'nchan': {
         'dict_key': 'number_channels',
         'description': 'number of channels',
         'width': 6,
         'format': '6.0f',
+        'align': '>',
+    },
+    'open': {
+        'dict_key': 'openings',
+        'description': 'number of channel openings in timeframe',
+        'width': 6,
+        'format': '6.0f',
+        'align': '>',
+    },
+    'openmed': {
+        'dict_key': 'opening_median_time',
+        'description': 'median opening time [blocks]',
+        'width': 7,
+        'format': '7.2f',
+        'align': '>',
+    },
+    'openavg': {
+        'dict_key': 'opening_average_time',
+        'description': 'average opening time [blocks]',
+        'width': 7,
+        'format': '7.2f',
+        'align': '>',
+    },
+    'openrel': {
+        'dict_key': 'relative_openings',
+        'description': 'number of channel openings per number of total channels of node in timeframe [1/time]',
+        'width': 8,
+        'format': '8.2f',
+        'align': '>',
+    },
+    'opencap': {
+        'dict_key': 'openings_total_capacity',
+        'description': 'total capacity of channel openings in timeframe [ksat/time]',
+        'width': 7,
+        'format': '7.3f',
+        'align': '>',
+    },
+    'opencaprel': {
+        'dict_key': 'relative_total_capacity',
+        'description': 'total capacity of channel openings per capacity of node in timeframe [1/time]',
+        'width': 11,
+        'format': '11.2f',
+        'align': '>',
+    },
+    'openavgcap': {
+        'dict_key': 'openings_average_capacity',
+        'description': 'average channel capacity of channel openings in timeframe [ksat/time]',
+        'width': 11,
+        'format': '11.8f',
         'align': '>',
     },
     'rpk': {
@@ -56,16 +135,16 @@ print_node_format = {
         'format': '<66',
         'align': '^',
     },
-    'cap': {
-        'dict_key': 'total_capacity',
-        'description': 'total capacity [sat]',
-        'width': 10,
-        'format': '10.0f',
-        'align': '>',
-    },
     'tot': {
         'dict_key': 'total_forwarding',
         'description': 'total forwarded [sat]',
+        'width': 9,
+        'format': '9d',
+        'align': '>',
+    },
+    'weight': {
+        'dict_key': 'weight',
+        'description': 'forwarding weight',
         'width': 9,
         'format': '9d',
         'align': '>',
@@ -81,6 +160,28 @@ class RecommendNodes(object):
         self.node = node
         self.show_connected = show_connected
         self.show_address = show_addresses
+        self.network_analysis = NetworkAnalysis(self.node)
+
+    def print_flow_analysis(self, out_direction=True, number_of_nodes=20, forwarding_events=200, sort_by='weight'):
+        nodes = self.flow_analysis(out_direction, last_forwardings_to_analyze=forwarding_events)
+        format_string = 'rpk,nchan,cap,cpc,alias'
+        self.print_nodes(nodes, number_of_nodes, format_string, sort_by=sort_by)
+
+    def print_good_old(self, number_of_nodes=20, sort_by='tot'):
+        nodes = self.good_old()
+        format_string = 'rpk,tot,flow,nchan,cap,cpc,alias'
+        self.print_nodes(nodes, number_of_nodes, format_string, sort_by)
+
+    def print_nodefile(self, source, distributing_nodes, number_of_nodes=20, sort_by='cap'):
+        nodes = self.nodefile(source, distributing_nodes)
+        logger.info(f"Showing nodes from source {source}.")
+        format_string = 'rpk,con,nchan,cap,cpc,alias'
+        self.print_nodes(nodes, number_of_nodes, format_string, sort_by=sort_by)
+
+    def print_channel_openings(self, from_days_ago=14, number_of_nodes=20, sort_by='open'):
+        nodes = self.channel_opening_statistics(from_days_ago)
+        format_string = 'rpk,open,opencap,openrel,opencaprel,openavgcap,openmed,openavg,nchan,cap,cpc,age,alias'
+        self.print_nodes(nodes, number_of_nodes, format_string, sort_by=sort_by)
 
     def good_old(self):
         """
@@ -90,8 +191,6 @@ class RecommendNodes(object):
         forwarding_analyzer = ForwardingAnalyzer(self.node)
         forwarding_analyzer.initialize_forwarding_data(0, time.time())  # analyze all historic forwardings
         nodes = forwarding_analyzer.get_forwarding_statistics_nodes()
-        if not self.show_connected:
-            nodes = self.exclude_connected_nodes(nodes)
         nodes = self.add_metadata_and_remove_pruned(nodes)
         return nodes
 
@@ -106,8 +205,6 @@ class RecommendNodes(object):
         forwarding_analyzer.initialize_forwarding_data(0, time.time())  # analyze all historic forwardings
         nodes_in, nodes_out = forwarding_analyzer.simple_flow_analysis(last_forwardings_to_analyze)
         raw_nodes = nodes_out if out_direction else nodes_in
-        if not self.show_connected:
-            raw_nodes = self.exclude_connected_nodes(raw_nodes)
         nodes = self.add_metadata_and_remove_pruned(raw_nodes)
         return nodes
 
@@ -181,24 +278,51 @@ class RecommendNodes(object):
 
         nodes = self.add_metadata_and_remove_pruned(nodes, exclude_hubs)
 
-        if not self.show_connected:
-            nodes = self.exclude_connected_nodes(nodes)
+        return nodes
+
+    def channel_opening_statistics(self, from_days_ago):
+        """
+        Fetches the channel opening statistics of the last `from_days_ago` days for the network analysis class and
+        adds some additional heuristics.
+
+        :param from_days_ago: int
+        :return: dict, keys: node public keys, values: several heuristics
+        """
+
+        nodes = self.network_analysis.calculate_channel_opening_statistics(from_days_ago)
+        nodes = self.add_metadata_and_remove_pruned(nodes)
+
+        # add the node age and other interesting metrics
+        for n, nv in nodes.items():
+            node_age = self.node.network.node_age(n)
+            nodes[n]['age_days'] = node_age
+            # goal of this metric: find bust-like channel openings of older nodes
+            # the motivation behind this is that this could be the behavior of a node which first did testing on
+            # some service, but then all of a sudden goes live, whose moment we want to catch
+            nodes[n]['metric_burst'] = nv['relative_total_capacity'] * (nv['openings_total_capacity']) ** 2 * node_age \
+                / max(1, nv['opening_median_time'])  # avoid division by zero
+            # goal of this metric: find steady nodes with lots of capacity opening
+            # the motivation behind this is that this could be the behavior of experienced node operators
+            # who dedicate themselves to their nodes and add a lot of value to the network
+            nodes[n]['metric_steady'] = nv['opening_median_time'] * (nv['openings_total_capacity'])**2
 
         return nodes
 
     def add_metadata_and_remove_pruned(self, nodes, exclude_hubs=False):
         """
-        Adds metadata like the number of channels, total capacity, ip address to the dict of nodes. If exclude_hubs is
-        set to True, big nodes will be removed from nodes.
+        Adds metadata like the number of channels, total capacity, ip address to the dict of nodes.
+
+        This should be added to every node recommendation method, as it cleans out the obvious bad nodes to
+        which we don't want to connect to.
+
+        If exclude_hubs is set to True, big nodes will be removed from nodes.
+
         :param nodes: dict
         :param exclude_hubs: bool
         :return: dict
         """
+
         nodes_new = {}
-        number_nodes = len(nodes.keys())
-        logger.info(f"Found {number_nodes} nodes for node recommendation.")
-        if exclude_hubs:
-            logger.info(f"Excluding hubs (defined by number of channels > {_settings.NUMBER_CHANNELS_DEFINING_HUB}).")
         for counter, (k, n) in enumerate(nodes.items()):
             try:
                 # copy all the entries
@@ -209,8 +333,8 @@ class RecommendNodes(object):
                 total_capacity = self.node.network.node_capacity(k)
                 node_new['number_channels'] = number_channels
                 if number_channels > 0:
-                    node_new['total_capacity'] = total_capacity
-                    node_new['capacity_per_channel'] = float(total_capacity) / number_channels
+                    node_new['total_capacity'] = float(total_capacity) / 1E8  # in btc
+                    node_new['capacity_per_channel'] = float(total_capacity) / number_channels / 1E8  # in btc
                     node_new['address'] = self.node.network.node_address(k)
                     if exclude_hubs:
                         if node_new['number_channels'] < _settings.NUMBER_CHANNELS_DEFINING_HUB:
@@ -220,14 +344,21 @@ class RecommendNodes(object):
             except KeyError:  # it was a pruned node if it is not found in the graph and it shouldn't be recommended
                 pass
 
+        if exclude_hubs:
+            logger.info(f"Excluding hubs (defined by number of channels > {_settings.NUMBER_CHANNELS_DEFINING_HUB}).")
+        if not self.show_connected:
+            nodes_new = self.exclude_connected_nodes(nodes_new)
+
         return nodes_new
 
     def exclude_connected_nodes(self, nodes):
         """
         Excludes already connected nodes from the nodes dict.
+
         :param nodes: dict, keys are node pub keys
         :return: dict
         """
+
         logger.debug("Filtering nodes which are not connected to us.")
         open_channels = self.node.get_open_channels()
         connected_node_pubkeys = set()
@@ -242,47 +373,35 @@ class RecommendNodes(object):
 
         return filtered_nodes
 
-    def print_flow_analysis(self, out_direction=True, number_of_nodes=20, forwarding_events=200):
-        nodes = self.flow_analysis(out_direction, last_forwardings_to_analyze=forwarding_events)
-        if len(nodes) == 0:
-            logger.info(">>> Did not find historic recordings of forwardings, therefore cannot recommend any node.")
-        else:
-            sorted_nodes = OrderedDict(sorted(nodes.items(), key=lambda x: -x[1]['weight']))
-            logger.debug(f"Found {len(sorted_nodes)} nodes in flow analysis.")
-            self.print_nodes(nodes, number_of_nodes, 'rpk,nchan,cap,cpc,alias')
-
-    def print_good_old(self, number_of_nodes=20, sort_by='tot'):
-        nodes = self.good_old()
-        if len(nodes) == 0:
-            logger.info(">>> Did not find historic recordings of forwardings, therefore cannot recommend any node.")
-        else:
-            sorted_nodes = OrderedDict(sorted(nodes.items(),
-                                              key=lambda x: -x[1][print_node_format[sort_by]['dict_key']]))
-            logger.debug(f"Found {len(sorted_nodes)} nodes as good old nodes.")
-            logger.debug(f"Sorting nodes by {sort_by}.")
-            self.print_nodes(sorted_nodes, number_of_nodes, 'rpk,tot,flow,nchan,cap,cpc,alias')
-
-    def print_nodefile(self, source, distributing_nodes, number_of_nodes=20, sort_by='cap'):
-        nodes = self.nodefile(source, distributing_nodes)
-        if len(nodes) == 0:
-            logger.info("Did not find any nodes in the file/url provided.")
-        else:
-            logger.info(f"Showing nodes from source {source}.")
-            sorted_nodes = OrderedDict(sorted(nodes.items(),
-                                              key=lambda x: -x[1][print_node_format[sort_by]['dict_key']]))
-            logger.debug(f"Found {len(sorted_nodes)} nodes as good old nodes.")
-            logger.debug(f"Sorting nodes by {sort_by}.")
-            self.print_nodes(sorted_nodes, number_of_nodes, 'rpk,con,nchan,cap,cpc,alias')
-
-    def print_nodes(self, nodes, number_of_nodes, columns):
+    def print_nodes(self, nodes, number_of_nodes, columns, sort_by):
         """
         General purpose printing function for flexible node tables.
-        Colums is a string, which includes the order and items of columns with a comma delimiter like so:
+
+        Columns is a string, which includes the order and items of columns with a comma delimiter like so:
         columns = "rpk,nchan,cap,cpc,a"
+
+        Sorting can be reversed by adding a "rev_" string before the sorting string.
+
         :param nodes: dict
         :param number_of_nodes: int
         :param columns: str
+        :param sort_by: str, sorting string, these can be the keys of the node dictionary
         """
+
+        if len(nodes) == 0:
+            logger.info(">>> Did not find any nodes.")
+        else:
+            logger.info(f"Found {len(nodes.keys())} nodes for node recommendation.")
+
+        # some logic to reverse the sorting order
+        reverse_sorting = True  # largest first
+        if sort_by[:4] == 'rev_':  # if there is a marker 'rev_' in front, reverse the sorting
+            reverse_sorting = False
+            sort_by = sort_by[4:]
+        nodes = OrderedDict(sorted(nodes.items(), key=lambda x: x[1][print_node_format[sort_by]['dict_key']],
+                                   reverse=reverse_sorting))
+        logger.info(f"Sorting nodes by {sort_by}.")
+
         logger.info("-------- Description --------")
         columns = columns.split(',')
         for c in columns:
@@ -300,6 +419,7 @@ class RecommendNodes(object):
             # print each row in a formated way specified in the print_node dictionary
             row = [f"{v[print_node_format[c]['dict_key']]:{print_node_format[c]['format']}}"
                    for c in columns if c != 'rpk']
+            # add whitespace buffers between columns
             row_string = " ".join(row)
             row_string = k + " " + row_string
             logger.info(row_string)

--- a/lndmanage.py
+++ b/lndmanage.py
@@ -59,7 +59,7 @@ class Parser(object):
                  'The flag excludes channels with an absolute unbalancedness smaller than UNBALANCEDNESS.')
 
         # subcmd: listchannels inactive
-        parser_listchannels_inactive = listchannels_subparsers.add_parser(
+        listchannels_subparsers.add_parser(
             'inactive', help="displays inactive channels")
 
         # subcmd: listchannels forwardings
@@ -119,7 +119,7 @@ class Parser(object):
         self.parser_circle.add_argument(
             '--reckless', help='Execute action in the network.', action='store_true')
 
-        # cmd: recommend-node
+        # cmd: recommend-nodes
         self.parser_recommend_nodes = subparsers.add_parser(
             'recommend-nodes', help='recommends nodes [see also subcommands with -h]',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -131,7 +131,8 @@ class Parser(object):
             help='specifies if node addresses should be shown')
         parser_recommend_nodes_subparsers = self.parser_recommend_nodes.add_subparsers(dest='subcmd')
 
-        # subcmd: recommend-node good-old
+        # TODO: put global options to the parent parser (e.g. number of nodes, sort-by flag)
+        # subcmd: recommend-nodes good-old
         parser_recommend_nodes_good_old = parser_recommend_nodes_subparsers.add_parser(
             'good-old', help='shows nodes already interacted with but no active channels',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -140,7 +141,7 @@ class Parser(object):
         parser_recommend_nodes_good_old.add_argument(
             '--sort-by', default='tot', type=str, help="sort by column [abbreviation, e.g. 'tot']")
 
-        # subcmd: recommend-node flow-analysis
+        # subcmd: recommend-nodes flow-analysis
         parser_recommend_nodes_flow_analysis = parser_recommend_nodes_subparsers.add_parser(
             'flow-analysis', help='recommends nodes from a flow analysis',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -152,8 +153,10 @@ class Parser(object):
         parser_recommend_nodes_flow_analysis.add_argument(
             '--inwarding-nodes', action='store_true',
             help='if True, inwarding nodes are displayed instead of outwarding')
+        parser_recommend_nodes_flow_analysis.add_argument(
+            '--sort-by', default='weight', type=str, help="sort by column [abbreviation, e.g. 'nchan']")
 
-        # subcmd: recommend-node nodefile
+        # subcmd: recommend-nodes nodefile
         parser_recommend_nodes_nodefile = parser_recommend_nodes_subparsers.add_parser(
             'nodefile', help='recommends nodes from a given file/url',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -168,6 +171,19 @@ class Parser(object):
             help='if True, distributing nodes are displayed instead of the bare nodes')
         parser_recommend_nodes_nodefile.add_argument(
             '--sort-by', default='cpc', type=str, help="sort by column [abbreviation, e.g. 'nchan']")
+
+        # subcmd: recommend-nodes channel-openings
+        parser_recommend_nodes_channel_openings = parser_recommend_nodes_subparsers.add_parser(
+            'channel-openings', help='recommends nodes from recent channel openings',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser_recommend_nodes_channel_openings.add_argument(
+            '--nnodes', default=20, type=int, help='sets the number of nodes displayed')
+        parser_recommend_nodes_channel_openings.add_argument(
+            '--from-days-ago', type=int,
+            default=30,
+            help='channel openings starting from a time frame days ago')
+        parser_recommend_nodes_channel_openings.add_argument(
+            '--sort-by', default='msteady', type=str, help="sort by column [abbreviation, e.g. 'nchan']")
 
     def parse_arguments(self):
         return self.parser.parse_args()
@@ -242,9 +258,13 @@ def main():
             recommend_nodes.print_good_old(number_of_nodes=args.nnodes, sort_by=args.sort_by)
         elif args.subcmd == 'flow-analysis':
             recommend_nodes.print_flow_analysis(out_direction=(not args.inwarding_nodes),
-                                                number_of_nodes=args.nnodes, forwarding_events=args.forwarding_events)
+                                                number_of_nodes=args.nnodes, forwarding_events=args.forwarding_events,
+                                                sort_by=args.sort_by)
         elif args.subcmd == 'nodefile':
             recommend_nodes.print_nodefile(args.source, distributing_nodes=args.distributing_nodes,
+                                           number_of_nodes=args.nnodes, sort_by=args.sort_by)
+        elif args.subcmd == 'channel-openings':
+            recommend_nodes.print_channel_openings(from_days_ago=args.from_days_ago,
                                            number_of_nodes=args.nnodes, sort_by=args.sort_by)
 
 


### PR DESCRIPTION
An analysis of recent channel openings in the network is added.

The channel ids in the lightning network contain encoded the block height of their creation date. This can be used to analyze which nodes have experienced channel openings (initiated by themselves, or by their channel partners). An increased activity of a node could indicate that it is doing something interesting, like preparing for a shop launch/service launch. It could also indicate that this node wants to be a routing node, but lacks inbound liquidity. It is therefore a good idea to connect to them.

Several metrics are being considered here:
```
open       number of channel openings in timeframe
opencap    total capacity of channel openings in timeframe [btc/time]
openrel    number of channel openings per number of total channels of node in timeframe [1/time]
opencaprel total capacity of channel openings per capacity of node in timeframe [1/time]
openavgcap average channel capacity of channel openings in timeframe [btc/time]
openmed    median opening time [blocks]
openavg    average opening time [blocks]
```
Especially the openmed and opencaprel, together with the node age could be used to craft more meaningful heuristics of types of channel openings, for example look for for bursts of channel openings of old nodes. This pattern could be the case of a developer's node that is suddenly used for services.
