### PR TITLE
update-fees: iterative fee optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current feature list (use the ```--help``` flag for subcommands):
   * ```recommend-nodes channel-openings``` based on recent channel 
   openings in the network: find nodes which show increased recent channel 
   opening activity 
+* __```update-fees``` optimize channel fee rates__
    
 **DISCLAIMER: This is BETA software, so please be careful (All actions are 
   executed as a dry run unless you call lndmanage with the ```--reckless``` 

--- a/lib/fee_setting.py
+++ b/lib/fee_setting.py
@@ -212,12 +212,13 @@ class FeeSetter(object):
         # remote balance should have an influence also in the case when
         # the fees were zero
         # fees_sat = max(fees_sat, 0.1)
-        # maximal change in percent: 1-c_max ... 1+c_max
+        # maximal change in percent: 1-c_min ... 1+c_max
+        c_min = 0.25
         c_max = 0.50
         # model:
         # change = m * fee / fee_rate_old / time_interval / remote_balance + t
 
-        t = 1 - c_max
+        t = 1 - c_min
 
         # max_x defines what demand means to us:
         # if 10% of a channel's balance was transacted in a week,
@@ -225,7 +226,7 @@ class FeeSetter(object):
         # TODO: optimize this parameter
         max_x = 0.1 / 7
 
-        m = 2 * c_max / max_x
+        m = 2 * (c_max + c_min) / max_x
         c = m * x + t
 
         if c > 1:

--- a/lib/fee_setting.py
+++ b/lib/fee_setting.py
@@ -1,58 +1,223 @@
-import grpc_compiled.rpc_pb2 as ln
-
 import logging
+import time
+
+from lib.user import yes_no_question
+from lib.forwardings import ForwardingAnalyzer
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-CLTV = 40
 
-
-def set_fees_by_balancedness(
-        node, base_unbalanced_msat, rate_unbalanced_decimal, base_balanced_msat, rate_balanced_decimal,
-        unbalancedness=0.90):
+class FeeSetter(object):
     """
-    Can be used to set fees differently for balanced and unbalanced channels.
-    TODO: refactor out lnd api calls into :class:`lib.node.LndNode`
-
-    :param node: :class:`lib.node.LndNode` instance
-    :param base_unbalanced_msat: int
-    :param rate_unbalanced_decimal: float (e.g. 0.00001 = 0.001 %)
-    :param base_balanced_msat: int
-    :param rate_balanced_decimal: float (e.g. 0.00001 = 0.001 %)
-    :param unbalancedness: float between 0 ... 1 (0: very balanced, 1: very unbalanced)
+    Class for setting fees.
     """
+    def __init__(self, node):
+        """
+            :param: node: `class`:lib.node.Node
+        """
+        self.node = node
+        self.forwarding_analyzer = ForwardingAnalyzer(node)
+        self.channel_fee_settings = node.get_channel_fee_policies()
 
-    channels = node.get_unbalanced_channels()
-    logger.info(f"-------- unbalanced channels (|ub| > {unbalancedness}) ---------")
-    channels.sort(key=lambda x: abs(x['unbalancedness']), reverse=True)
-    print_divide = 0
+    def set_fees_demand(self, cltv=20, base_fee_msat=30, from_days_ago=7,
+                        min_fee_rate=0.000001, reckless=False):
+        """
+        Sets channel fee rates by estimating an economic demand factor.
 
-    for c in channels:
-        logger.info(f"|ub|: {abs(c['unbalancedness']):1.4f} c: {c['chan_id']} a: {c['alias']}")
+        The change factor is based on four quantities, the unbalancedness,
+        the fund flow, the fees collected (in a certain time frame) and
+        the remaining remote balance.
 
-        cp_parts = c['channel_point'].split(':')
+        :param cltv: int
+        :param base_fee_msat: int
+        :param from_days_ago: int, forwarding history is taken over the past
+                                   from_days_ago
+        :param min_fee_rate: float, the fee rate will be not set lower than
+                                    this amount
+        :param reckless: bool, if set, there won't be any user interaction
+        """
+        time_end = time.time()
+        time_start = time_end - from_days_ago * 24 * 60 * 60
 
-        channel_point = ln.ChannelPoint(funding_txid_str=cp_parts[0], output_index=int(cp_parts[1]))
+        self.forwarding_analyzer.initialize_forwarding_data(
+            time_start, time_end)
 
-        if abs(c['unbalancedness']) > unbalancedness:  # unbalanced
-            new_base = base_unbalanced_msat
-            new_rate = rate_unbalanced_decimal
-        else:  # balanced
-            if print_divide == 0:
-                logger.info(f"-------- balanced channels (|ub| < {unbalancedness}) --------")
-                print_divide = 1
+        channels = self.node.get_all_channels()
+        channels_forwarding_stats = \
+            self.forwarding_analyzer.get_forwarding_statistics_channels()
+        channel_fee_policies = self.fee_rate_change(
+            channels, channels_forwarding_stats, base_fee_msat, cltv,
+            min_fee_rate)
 
-            new_base = base_balanced_msat
-            new_rate = rate_balanced_decimal
+        if not reckless:
+            logger.info("Do you want to set these fees? Enter [yes/no]:")
+            if yes_no_question():
+                self.node.set_channel_fee_policies(channel_fee_policies)
+        else:
+            self.node.set_channel_fee_policies(channel_fee_policies)
 
-        update_request = ln.PolicyUpdateRequest(
-            chan_point=channel_point,
-            base_fee_msat=new_base,
-            fee_rate=new_rate,
-            time_lock_delta=CLTV,
-        )
-        logger.debug(update_request)
-        # node._stub.UpdateChannelPolicy(request=update_request)
+    def fee_rate_change(self, channels, channels_forwarding_stats,
+                        base_fee_msat, cltv, min_fee_rate=0.000001):
+        """
+        Calculates and reports the changes of the new fee policy.
+
+        :param channels: dict with basic channel information
+        :param channels_forwarding_stats: dict with forwarding information
+        :param base_fee_msat: int
+        :param cltv: int
+        :param min_fee_rate: float, the fee rate will be not smaller than this
+                                    parameter
+        :return: dict, channel fee policies
+        """
+        logger.info("Determining new channel policies based on demand.")
+        logger.info("Every channel will have a base fee of %d msat and cltv "
+                    "of %d.", base_fee_msat, cltv)
+
+        channel_fee_policies = {}
+
+        for channel_id, channel_data in channels.items():
+            channel_stats = channels_forwarding_stats.get(channel_id, None)
+            if channel_stats is None:
+                flow = 0
+                fees_sat = 0
+            else:
+                flow = channel_stats['flow_direction']
+                fees_sat = channel_stats['fees_total'] // 1000
+
+            ub = channel_data['unbalancedness']
+            remote_balance = channel_data['remote_balance']
+            remote_balance = max(1, remote_balance)  # avoid zero division
+
+            fee_rate = \
+                self.channel_fee_settings[
+                    channel_data['channel_point']]['fee_rate']
+
+            logger.info(">>> New channel policy for channel %s", channel_id)
+            logger.info(
+                "    ub: %0.2f flow: %0.2f, fees: %d sat, rb: %d sat. ",
+                ub, flow, fees_sat, remote_balance)
+
+            factor_demand = self.factor_demand(fees_sat, remote_balance)
+            factor_unbalancedness = self.factor_unbalancedness(ub)
+            factor_flow = self.factor_unbalancedness(flow)
+
+            # define weights
+            wgt_demand = 1.2
+            wgt_ub = 0.7
+            wgt_flow = 0.5
+
+            # calculate weighted change
+            weighted_change = (
+                wgt_ub * factor_unbalancedness +
+                wgt_flow * factor_flow +
+                wgt_demand * factor_demand
+            ) / (wgt_ub + wgt_flow + wgt_demand)
+
+            logger.info(
+                "    Change factors: demand: %1.3f, "
+                "unbalancedness %1.3f, flow: %1.3f. Weighted change: %1.3f",
+                factor_demand, factor_unbalancedness, factor_flow,
+                weighted_change)
+
+            fee_rate_new = fee_rate * weighted_change
+            fee_rate_new = max(min_fee_rate, fee_rate_new)
+
+            logger.info("    Fee rate: %1.6f -> %1.6f",
+                        fee_rate, fee_rate_new)
+
+            channel_fee_policies[channel_data['channel_point']] = {
+                'base_fee_msat': base_fee_msat,
+                'fee_rate': fee_rate_new,
+                'cltv': cltv,
+            }
+
+        return channel_fee_policies
+
+    @staticmethod
+    def factor_unbalancedness(ub):
+        """
+        Calculates a change rate for the unbalancedness.
+
+        The lower the unbalancedness, the lower the fee rate should be.
+        This encourages outward flow through this channel.
+
+        :param ub: float, in [-1 ... 1]
+        :return: float, [1-c_max, 1+c_max]
+
+        """
+        # maximal change
+        c_max = 0.25
+        # give unbalancedness a more refined weight
+        rescale = 0.5
+
+        c = 1 + ub * rescale
+        # limit the change
+        if c > 1:
+            return min(c, 1 + c_max)
+        else:
+            return max(c, 1 - c_max)
+
+    @staticmethod
+    def factor_flow(flow):
+        """
+        Calculates a change rate for the flow rate.
+
+        If forwardings are predominantly flowing outward, we want to increase
+        the fee rate, because there seems to be demand.
+
+        :param flow: float, [-1 ... 1]
+        :return: float, [1-c_max, 1+c_max]
+        """
+        c_max = 0.25
+        rescale = 0.5
+        c = 1 + flow * rescale
+
+        # limit the change
+        if c > 1:
+            return min(c, 1 + c_max)
+        else:
+            return max(c, 1 - c_max)
+
+    @staticmethod
+    def factor_demand(fees_sat, remote_balance_sat):
+        """
+        Calculates a change factor by taking into account the fees collected
+        and the remote balance left.
+
+        The higher the fees collected, the larger the fee rate should be. Also
+        if there is only a small amount of remote balance left, we also want to
+        increase the fee rate.
+
+        The model for the change rate is determined by a linear function:
+        change = m * fee / remote_balance + t
+
+        :param fees_sat:
+        :param remote_balance_sat:
+        :return: float, [1-c_max, 1+c_max]
+        """
+
+        # remote balance should have an influence also in the case when
+        # the fees were zero
+        fees_sat = max(fees_sat, 0.1)
+        # maximal change in percent: 1-c_max ... 1+c_max
+        c_max = 0.25
+        # model:
+        # change = m * fee / remote_balance + t
+
+        # empirical parameter (determined by channel with most demand)
+        fee_per_remote_max = 1E-5
+
+        m = 2 * c_max / fee_per_remote_max
+        # chosen such, that at zero fees, we get c = 1 - c_max
+        t = 1 - c_max
+
+        c = m * (fees_sat / remote_balance_sat) + t
+
+        if c > 1:
+            return min(c, 1 + c_max)
+        else:
+            return c
 
 
 if __name__ == '__main__':
@@ -62,8 +227,5 @@ if __name__ == '__main__':
     logging.config.dictConfig(_settings.logger_config)
 
     nd = LndNode()
-
-    set_fees_by_balancedness(
-        nd, base_unbalanced_msat=0, rate_unbalanced_decimal=0.000001,
-        base_balanced_msat=40, rate_balanced_decimal=0.000050)
-
+    fee_setter = FeeSetter(nd)
+    fee_setter.set_fees_demand()

--- a/lib/forwardings.py
+++ b/lib/forwardings.py
@@ -249,8 +249,10 @@ class ForwardingAnalyzer(object):
                     else edge_data_out['node2_pub']
 
                 # nodes involved in the forwarding process should be removed
-                excluded_nodes = [self.node.pub_key, incoming_node_pub_key,
-                    outgoing_node_pub_key]
+                excluded_nodes = [
+                    self.node.pub_key, incoming_node_pub_key,
+                    outgoing_node_pub_key
+                ]
 
                 # determine all the nearest and second nearest
                 # neighbors (they may appear more than once)

--- a/lib/user.py
+++ b/lib/user.py
@@ -1,3 +1,9 @@
+import logging
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
 def yes_no_question():
     """
     Asks the user a yes/no question and translates it into bool.
@@ -13,4 +19,4 @@ def yes_no_question():
     elif choice in no:
         return False
     else:
-        print("Please respond with 'yes' or 'no'")
+        logger.info("Please respond with 'yes' or 'no'")

--- a/tests/test_fee_setting.py
+++ b/tests/test_fee_setting.py
@@ -1,0 +1,17 @@
+from lib.fee_setting import FeeSetter
+from lib.node import LndNode
+
+if __name__ == '__main__':
+    node = LndNode()
+    fee_setter = FeeSetter(node)
+
+    print(fee_setter.factor_demand(32, 3500000))
+    print(fee_setter.factor_demand(31, 3000000))
+    print(fee_setter.factor_demand(27, 2000000))
+    print(fee_setter.factor_demand(18, 2500000))
+    print(fee_setter.factor_demand(7, 1300000))
+    print(fee_setter.factor_demand(4, 250000))
+    print(fee_setter.factor_demand(4, 1000000))
+    print(fee_setter.factor_demand(2, 100000))
+    print(fee_setter.factor_demand(0, 100000))
+    print(fee_setter.factor_demand(0.440, 1000000))


### PR DESCRIPTION
A new command `update-fees` is added to lndmanage.

This command increases/decreases the fee rate of all the channels by a maximal amount of +/-50% by taking into account the unbalancedness, the flow direction and the demand for the individual channel.

The goal is to increase the fee rate of highly used outgoing channels and decrease the fee rate for barely used outgoing channels, thereby going to a fee setting, where fees are maximized and channels are balanced. This is achieved by weighting the three change factors of unbalancedness, flow, and demand in a certain way:

```
wgt_demand = 1.2
wgt_ub = 1.0
wgt_flow = 0.5
```
to calculate the overall change:
```
change_fee_rate = 
(change_demand * wgt_demand + change_ub * wgt_ub + change_flow * wgt_flow) / 
(wgt_demand + wgt_ub + wgt_flow)
```
and to set the new fee rate as:
`fee_rate_new = change_fee_rate * fee_rate_old`

The individual change factors are determined by:

**Unbalancedness**
`change_ub = 1 + ub * 0.5` (with min, max = 0.50, 1.50):
Unbalancedness is a value between [-1, 1], where 0 reflects a perfect balance between local and remote balance. Fees for channels with a lot of remote balance (large `ub`) should be high, discouraging outgoing payments and should be low for channels with a lot of local balance.

**Flow**
`change_flow = 1 + flow * 0.5` (with min, max = 0.50, 1.50)
Flow is a value between [-1, 1] depending on the overall flow of funds, where -1 is only inward flow, 1 is outward flow in a certain time frame. Fees for channels with a lot of outward flow (large `flow`) should be high, as this partly reflects the demand for this channel.

**Demand** 
(min, max = 0.75, 1.50)
`change_demand = m * (fees_sat / fee_rate / time_interval / capacity) + t`, where `fees_sat` are the fees collected in the past (`--from-days-ago`) days and `fee_rate` is the present fee_rate. In this way we can estimate how many sat were forwarded on that channel. This can then be set in relation to the capacity of the channel and the time interval in which that occured. At the moment maximal demand is defined as when 10% of the channel's capacity was forwarded within 7 days by the proportionality factor `m`. It is chosen such that a meaningful adjustment is carried out if there is reasonable demand (to be adjusted in the future) and `t` has a value such that the maximal fee rate reduction is 0.75. The maximal change is capped at 1.50.

The command is recommended to be run in a certain time interval of say 7 days (can be adjusted by the user depending on the number of forwardings on the node). In this way, the channel fees should converge towards a more optimal fee setting, which reflects the demand of the channel liquidity.