### PR TITLE
lndmanage: interactive mode when run without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,22 @@ then run
 ```
 If it works, you should see the node status.
 
+**Running lndmanage interactively (recommended)**
+
+lndmanage supports an interactive mode with command history. The interactive
+mode has the advantage that the network graph has to be read into memory only
+once, giving a much faster execution time for subsequent command invocations.
+
+Interacive mode is started by calling lndmanage without arguments:
+```bash
+$ lndmanage
+Running in interactive mode. You can type 'help' or 'exit'.
+$ lndmanage listchannels forwardings
+<output>
+$ lndmanage exit
+```
+Commands that can be entered are the ones you would give as arguments.
+
 Testing
 -------
 Requirements are an installation of [lnregtest](https://github.com/bitromortac/lnregtest)


### PR DESCRIPTION
This PR adds an interactive mode where the user is prompted for
entering the commands available for lndmanage. This has the advantage
that the network graph has to be read only once when entering the
interactive mode and makes subsequent execution much smoother.

If lndmanage is run with arguments the previous behavior is not changed,
such that it can be part of shell scripts.

The interactive session includes also a history of commands typed in, which
can be used to access the old commands in a typical history functionality of
a shell.