### PR TITLE
listchannels: command for hygiene of active channels

### DIFF
--- a/lndmanage/grpc_compiled/rpc.proto
+++ b/lndmanage/grpc_compiled/rpc.proto
@@ -777,6 +777,18 @@ service Lightning {
     */
     rpc SubscribeChannelBackups(ChannelBackupSubscription) returns (stream ChanBackupSnapshot) {
     };
+
+    /** lncli: `bakemacaroon`
+    BakeMacaroon allows the creation of a new macaroon with custom read and
+    write permissions. No first-party caveats are added since this can be done
+    offline.
+    */
+    rpc BakeMacaroon(BakeMacaroonRequest) returns (BakeMacaroonResponse) {
+        option (google.api.http) = {
+            post: "/v1/macaroon"
+            body: "*"
+        };
+    };
 }
 
 message Utxo {
@@ -885,7 +897,7 @@ message SendRequest {
     The channel id of the channel that must be taken to the first hop. If zero,
     any channel may be used.
     */
-    uint64 outgoing_chan_id = 9;
+    uint64 outgoing_chan_id = 9 [jstype = JS_STRING];
 
     /** 
     An optional maximum total time lock for the route. This should not exceed
@@ -1164,7 +1176,7 @@ message Channel {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 4 [json_name = "chan_id"];
+    uint64 chan_id = 4 [json_name = "chan_id", jstype = JS_STRING];
 
     /// The total amount of funds held in this channel
     int64 capacity = 5 [json_name = "capacity"];
@@ -1246,6 +1258,19 @@ message Channel {
     directly to that key. 
     */
     bool static_remote_key = 22 [json_name = "static_remote_key"];
+
+    /**
+    The number of seconds that the channel has been monitored by the channel
+    scoring system. Scores are currently not persisted, so this value may be
+    less than the lifetime of the channel [EXPERIMENTAL].
+    */
+    int64 lifetime = 23 [json_name = "lifetime"];
+
+    /**
+    The number of seconds that the remote peer has been observed as being online
+    by the channel scoring system over the lifetime of the channel [EXPERIMENTAL].
+    */
+    int64 uptime = 24 [json_name = "uptime"];
 }
 
 
@@ -1265,7 +1290,7 @@ message ChannelCloseSummary {
     string channel_point = 1 [json_name = "channel_point"];
 
     ///  The unique channel ID for the channel. 
-    uint64 chan_id = 2 [json_name = "chan_id"];
+    uint64 chan_id = 2 [json_name = "chan_id", jstype = JS_STRING];
 
     /// The hash of the genesis block that this channel resides within.
     string chain_hash = 3 [json_name = "chain_hash"];
@@ -1761,7 +1786,7 @@ message NodePair {
 
 message EdgeLocator {
     /// The short channel id of this edge.
-    uint64 channel_id = 1;
+    uint64 channel_id = 1 [jstype = JS_STRING];
 
     /**
     The direction of this edge. If direction_reverse is false, the direction
@@ -1792,7 +1817,7 @@ message Hop {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 1 [json_name = "chan_id"];
+    uint64 chan_id = 1 [json_name = "chan_id", jstype = JS_STRING];
     int64 chan_capacity = 2 [json_name = "chan_capacity"];
     int64 amt_to_forward = 3 [json_name = "amt_to_forward", deprecated = true];
     int64 fee = 4 [json_name = "fee", deprecated = true];
@@ -1811,6 +1836,32 @@ message Hop {
     TLV format.
     */
     bool tlv_payload = 9 [json_name = "tlv_payload"];
+
+    /**
+    An optional TLV record tha singals the use of an MPP payment. If present,
+    the receiver will enforce that that the same mpp_record is included in the
+    final hop payload of all non-zero payments in the HTLC set. If empty, a
+    regular single-shot payment is or was attempted.
+    */
+    MPPRecord mpp_record = 10 [json_name = "mpp_record"];
+}
+
+message MPPRecord {
+    /**
+    A unique, random identifier used to authenticate the sender as the intended
+    payer of a multi-path payment. The payment_addr must be the same for all
+    subpayments, and match the payment_addr provided in the receiver's invoice.
+    The same payment_addr must be used on all subpayments.
+    */
+    bytes payment_addr = 11 [json_name = "payment_addr"];
+
+    /**
+    The total amount in milli-satoshis being sent as part of a larger multi-path
+    payment. The caller is responsible for ensuring subpayments to the same node
+    and payment_hash sum exactly to total_amt_msat. The same
+    total_amt_msat must be used on all subpayments.
+    */
+    int64 total_amt_msat = 10 [json_name = "total_amt_msat"];
 }
 
 /**
@@ -1933,7 +1984,7 @@ message ChannelEdge {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 channel_id = 1 [json_name = "channel_id"];
+    uint64 channel_id = 1 [json_name = "channel_id", jstype = JS_STRING];
     string chan_point = 2 [json_name = "chan_point"];
 
     uint32 last_update = 3 [json_name = "last_update", deprecated = true];
@@ -1971,7 +2022,7 @@ message ChanInfoRequest {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 1;
+    uint64 chan_id = 1 [jstype = JS_STRING];
 }
 
 message NetworkInfoRequest {
@@ -2020,7 +2071,7 @@ message ChannelEdgeUpdate {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 1;
+    uint64 chan_id = 1 [jstype = JS_STRING];
 
     ChannelPoint chan_point = 2;
 
@@ -2037,7 +2088,7 @@ message ClosedChannelUpdate {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 1;
+    uint64 chan_id = 1 [jstype = JS_STRING];
     int64 capacity = 2;
     uint32 closed_height = 3;
     ChannelPoint chan_point = 4;
@@ -2048,7 +2099,7 @@ message HopHint {
     string node_id = 1 [json_name = "node_id"];
 
     /// The unique identifier of the channel.
-    uint64 chan_id = 2 [json_name = "chan_id"];
+    uint64 chan_id = 2 [json_name = "chan_id", jstype = JS_STRING];
 
     /// The base fee of the channel denominated in millisatoshis.
     uint32 fee_base_msat = 3 [json_name = "fee_base_msat"];
@@ -2202,7 +2253,7 @@ enum InvoiceHTLCState {
 /// Details of an HTLC that paid to an invoice
 message InvoiceHTLC {
     /// Short channel id over which the htlc was received.
-    uint64 chan_id = 1 [json_name = "chan_id"];
+    uint64 chan_id = 1 [json_name = "chan_id", jstype = JS_STRING];
 
     /// Index identifying the htlc on the channel.
     uint64 htlc_index = 2 [json_name = "htlc_index"];
@@ -2481,10 +2532,10 @@ message ForwardingEvent {
     uint64 timestamp = 1 [json_name = "timestamp"];
 
     /// The incoming channel ID that carried the HTLC that created the circuit.
-    uint64 chan_id_in = 2 [json_name = "chan_id_in"];
+    uint64 chan_id_in = 2 [json_name = "chan_id_in", jstype = JS_STRING];
 
     /// The outgoing channel ID that carried the preimage that completed the circuit.
-    uint64 chan_id_out = 4 [json_name = "chan_id_out"];
+    uint64 chan_id_out = 4 [json_name = "chan_id_out", jstype = JS_STRING];
 
     /// The total amount (in satoshis) of the incoming HTLC that created half the circuit.
     uint64 amt_in = 5 [json_name = "amt_in"];
@@ -2497,6 +2548,13 @@ message ForwardingEvent {
 
     /// The total fee (in milli-satoshis) that this payment circuit carried.
     uint64 fee_msat = 8 [json_name = "fee_msat"];
+
+    /// The total amount (in milli-satoshis) of the incoming HTLC that created half the circuit.
+    uint64 amt_in_msat = 9 [json_name = "amt_in_msat"];
+
+    /// The total amount (in milli-satoshis) of the outgoing HTLC that created the second half of the circuit.
+    uint64 amt_out_msat = 10 [json_name = "amt_out_msat"];
+
 
     // TODO(roasbeef): add settlement latency?
     //  * use FPE on the chan id?
@@ -2577,4 +2635,20 @@ message RestoreBackupResponse {}
 message ChannelBackupSubscription {}
 
 message VerifyChanBackupResponse {
+}
+
+message MacaroonPermission {
+    /// The entity a permission grants access to.
+    string entity = 1 [json_name = "entity"];
+
+    /// The action that is granted.
+    string action = 2 [json_name = "action"];
+}
+message BakeMacaroonRequest {
+    /// The list of permissions the new macaroon should grant.
+    repeated MacaroonPermission permissions = 1 [json_name = "permissions"];
+}
+message BakeMacaroonResponse {
+    /// The hex encoded macaroon, serialized in binary format.
+    string macaroon = 1 [json_name = "macaroon"];
 }

--- a/lndmanage/grpc_compiled/rpc_pb2.py
+++ b/lndmanage/grpc_compiled/rpc_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rpc.proto',
   package='lnrpc',
   syntax='proto3',
-  serialized_pb=_b('\n\trpc.proto\x12\x05lnrpc\x1a\x1cgoogle/api/annotations.proto\"A\n\x0eGenSeedRequest\x12\x19\n\x11\x61\x65zeed_passphrase\x18\x01 \x01(\x0c\x12\x14\n\x0cseed_entropy\x18\x02 \x01(\x0c\"H\n\x0fGenSeedResponse\x12\x1c\n\x14\x63ipher_seed_mnemonic\x18\x01 \x03(\t\x12\x17\n\x0f\x65nciphered_seed\x18\x02 \x01(\x0c\"\xb2\x01\n\x11InitWalletRequest\x12\x17\n\x0fwallet_password\x18\x01 \x01(\x0c\x12\x1c\n\x14\x63ipher_seed_mnemonic\x18\x02 \x03(\t\x12\x19\n\x11\x61\x65zeed_passphrase\x18\x03 \x01(\x0c\x12\x17\n\x0frecovery_window\x18\x04 \x01(\x05\x12\x32\n\x0f\x63hannel_backups\x18\x05 \x01(\x0b\x32\x19.lnrpc.ChanBackupSnapshot\"\x14\n\x12InitWalletResponse\"{\n\x13UnlockWalletRequest\x12\x17\n\x0fwallet_password\x18\x01 \x01(\x0c\x12\x17\n\x0frecovery_window\x18\x02 \x01(\x05\x12\x32\n\x0f\x63hannel_backups\x18\x03 \x01(\x0b\x32\x19.lnrpc.ChanBackupSnapshot\"\x16\n\x14UnlockWalletResponse\"G\n\x15\x43hangePasswordRequest\x12\x18\n\x10\x63urrent_password\x18\x01 \x01(\x0c\x12\x14\n\x0cnew_password\x18\x02 \x01(\x0c\"\x18\n\x16\x43hangePasswordResponse\"\xe1\x01\n\x04Utxo\x12.\n\x04type\x18\x01 \x01(\x0e\x32\x12.lnrpc.AddressTypeR\x0c\x61\x64\x64ress_type\x12\x18\n\x07\x61\x64\x64ress\x18\x02 \x01(\tR\x07\x61\x64\x64ress\x12\x1e\n\namount_sat\x18\x03 \x01(\x03R\namount_sat\x12\x1c\n\tpk_script\x18\x04 \x01(\tR\tpk_script\x12+\n\x08outpoint\x18\x05 \x01(\x0b\x32\x0f.lnrpc.OutPointR\x08outpoint\x12$\n\rconfirmations\x18\x06 \x01(\x03R\rconfirmations\"\xb9\x02\n\x0bTransaction\x12\x18\n\x07tx_hash\x18\x01 \x01(\tR\x07tx_hash\x12\x16\n\x06\x61mount\x18\x02 \x01(\x03R\x06\x61mount\x12,\n\x11num_confirmations\x18\x03 \x01(\x05R\x11num_confirmations\x12\x1e\n\nblock_hash\x18\x04 \x01(\tR\nblock_hash\x12\"\n\x0c\x62lock_height\x18\x05 \x01(\x05R\x0c\x62lock_height\x12\x1e\n\ntime_stamp\x18\x06 \x01(\x03R\ntime_stamp\x12\x1e\n\ntotal_fees\x18\x07 \x01(\x03R\ntotal_fees\x12&\n\x0e\x64\x65st_addresses\x18\x08 \x03(\tR\x0e\x64\x65st_addresses\x12\x1e\n\nraw_tx_hex\x18\t \x01(\tR\nraw_tx_hex\"\x18\n\x16GetTransactionsRequest\"L\n\x12TransactionDetails\x12\x36\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x12.lnrpc.TransactionR\x0ctransactions\"7\n\x08\x46\x65\x65Limit\x12\x0f\n\x05\x66ixed\x18\x01 \x01(\x03H\x00\x12\x11\n\x07percent\x18\x02 \x01(\x03H\x00\x42\x07\n\x05limit\"\xd8\x02\n\x0bSendRequest\x12\x0c\n\x04\x64\x65st\x18\x01 \x01(\x0c\x12\x13\n\x0b\x64\x65st_string\x18\x02 \x01(\t\x12\x0b\n\x03\x61mt\x18\x03 \x01(\x03\x12\x14\n\x0cpayment_hash\x18\x04 \x01(\x0c\x12\x1b\n\x13payment_hash_string\x18\x05 \x01(\t\x12\x17\n\x0fpayment_request\x18\x06 \x01(\t\x12\x18\n\x10\x66inal_cltv_delta\x18\x07 \x01(\x05\x12\"\n\tfee_limit\x18\x08 \x01(\x0b\x32\x0f.lnrpc.FeeLimit\x12\x18\n\x10outgoing_chan_id\x18\t \x01(\x04\x12\x12\n\ncltv_limit\x18\n \x01(\r\x12\x31\n\x08\x64\x65st_tlv\x18\x0b \x03(\x0b\x32\x1f.lnrpc.SendRequest.DestTlvEntry\x1a.\n\x0c\x44\x65stTlvEntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\"\xb8\x01\n\x0cSendResponse\x12$\n\rpayment_error\x18\x01 \x01(\tR\rpayment_error\x12*\n\x10payment_preimage\x18\x02 \x01(\x0cR\x10payment_preimage\x12\x32\n\rpayment_route\x18\x03 \x01(\x0b\x32\x0c.lnrpc.RouteR\rpayment_route\x12\"\n\x0cpayment_hash\x18\x04 \x01(\x0cR\x0cpayment_hash\"j\n\x12SendToRouteRequest\x12\x14\n\x0cpayment_hash\x18\x01 \x01(\x0c\x12\x1b\n\x13payment_hash_string\x18\x02 \x01(\t\x12\x1b\n\x05route\x18\x04 \x01(\x0b\x32\x0c.lnrpc.RouteJ\x04\x08\x03\x10\x04\"\xb5\x02\n\x14\x43hannelAcceptRequest\x12\x13\n\x0bnode_pubkey\x18\x01 \x01(\x0c\x12\x12\n\nchain_hash\x18\x02 \x01(\x0c\x12\x17\n\x0fpending_chan_id\x18\x03 \x01(\x0c\x12\x13\n\x0b\x66unding_amt\x18\x04 \x01(\x04\x12\x10\n\x08push_amt\x18\x05 \x01(\x04\x12\x12\n\ndust_limit\x18\x06 \x01(\x04\x12\x1b\n\x13max_value_in_flight\x18\x07 \x01(\x04\x12\x17\n\x0f\x63hannel_reserve\x18\x08 \x01(\x04\x12\x10\n\x08min_htlc\x18\t \x01(\x04\x12\x12\n\nfee_per_kw\x18\n \x01(\x04\x12\x11\n\tcsv_delay\x18\x0b \x01(\r\x12\x1a\n\x12max_accepted_htlcs\x18\x0c \x01(\r\x12\x15\n\rchannel_flags\x18\r \x01(\r\"@\n\x15\x43hannelAcceptResponse\x12\x0e\n\x06\x61\x63\x63\x65pt\x18\x01 \x01(\x08\x12\x17\n\x0fpending_chan_id\x18\x02 \x01(\x0c\"\xa2\x01\n\x0c\x43hannelPoint\x12\x30\n\x12\x66unding_txid_bytes\x18\x01 \x01(\x0cH\x00R\x12\x66unding_txid_bytes\x12,\n\x10\x66unding_txid_str\x18\x02 \x01(\tH\x00R\x10\x66unding_txid_str\x12\"\n\x0coutput_index\x18\x03 \x01(\rR\x0coutput_indexB\x0e\n\x0c\x66unding_txid\"j\n\x08OutPoint\x12\x1e\n\ntxid_bytes\x18\x01 \x01(\x0cR\ntxid_bytes\x12\x1a\n\x08txid_str\x18\x02 \x01(\tR\x08txid_str\x12\"\n\x0coutput_index\x18\x03 \x01(\rR\x0coutput_index\">\n\x10LightningAddress\x12\x16\n\x06pubkey\x18\x01 \x01(\tR\x06pubkey\x12\x12\n\x04host\x18\x02 \x01(\tR\x04host\"\xa1\x01\n\x12\x45stimateFeeRequest\x12\x41\n\x0c\x41\x64\x64rToAmount\x18\x01 \x03(\x0b\x32+.lnrpc.EstimateFeeRequest.AddrToAmountEntry\x12\x13\n\x0btarget_conf\x18\x02 \x01(\x05\x1a\x33\n\x11\x41\x64\x64rToAmountEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"c\n\x13\x45stimateFeeResponse\x12\x18\n\x07\x66\x65\x65_sat\x18\x01 \x01(\x03R\x07\x66\x65\x65_sat\x12\x32\n\x14\x66\x65\x65rate_sat_per_byte\x18\x02 \x01(\x03R\x14\x66\x65\x65rate_sat_per_byte\"\xb1\x01\n\x0fSendManyRequest\x12>\n\x0c\x41\x64\x64rToAmount\x18\x01 \x03(\x0b\x32(.lnrpc.SendManyRequest.AddrToAmountEntry\x12\x13\n\x0btarget_conf\x18\x03 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x05 \x01(\x03\x1a\x33\n\x11\x41\x64\x64rToAmountEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"&\n\x10SendManyResponse\x12\x12\n\x04txid\x18\x01 \x01(\tR\x04txid\"m\n\x10SendCoinsRequest\x12\x0c\n\x04\x61\x64\x64r\x18\x01 \x01(\t\x12\x0e\n\x06\x61mount\x18\x02 \x01(\x03\x12\x13\n\x0btarget_conf\x18\x03 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x05 \x01(\x03\x12\x10\n\x08send_all\x18\x06 \x01(\x08\"\'\n\x11SendCoinsResponse\x12\x12\n\x04txid\x18\x01 \x01(\tR\x04txid\":\n\x12ListUnspentRequest\x12\x11\n\tmin_confs\x18\x01 \x01(\x05\x12\x11\n\tmax_confs\x18\x02 \x01(\x05\"8\n\x13ListUnspentResponse\x12!\n\x05utxos\x18\x01 \x03(\x0b\x32\x0b.lnrpc.UtxoR\x05utxos\"5\n\x11NewAddressRequest\x12 \n\x04type\x18\x01 \x01(\x0e\x32\x12.lnrpc.AddressType\".\n\x12NewAddressResponse\x12\x18\n\x07\x61\x64\x64ress\x18\x01 \x01(\tR\x07\x61\x64\x64ress\"&\n\x12SignMessageRequest\x12\x10\n\x03msg\x18\x01 \x01(\x0cR\x03msg\"3\n\x13SignMessageResponse\x12\x1c\n\tsignature\x18\x01 \x01(\tR\tsignature\"F\n\x14VerifyMessageRequest\x12\x10\n\x03msg\x18\x01 \x01(\x0cR\x03msg\x12\x1c\n\tsignature\x18\x02 \x01(\tR\tsignature\"E\n\x15VerifyMessageResponse\x12\x14\n\x05valid\x18\x01 \x01(\x08R\x05valid\x12\x16\n\x06pubkey\x18\x02 \x01(\tR\x06pubkey\"I\n\x12\x43onnectPeerRequest\x12%\n\x04\x61\x64\x64r\x18\x01 \x01(\x0b\x32\x17.lnrpc.LightningAddress\x12\x0c\n\x04perm\x18\x02 \x01(\x08\"\x15\n\x13\x43onnectPeerResponse\"1\n\x15\x44isconnectPeerRequest\x12\x18\n\x07pub_key\x18\x01 \x01(\tR\x07pub_key\"\x18\n\x16\x44isconnectPeerResponse\"\x86\x01\n\x04HTLC\x12\x1a\n\x08incoming\x18\x01 \x01(\x08R\x08incoming\x12\x16\n\x06\x61mount\x18\x02 \x01(\x03R\x06\x61mount\x12\x1c\n\thash_lock\x18\x03 \x01(\x0cR\thash_lock\x12,\n\x11\x65xpiration_height\x18\x04 \x01(\rR\x11\x65xpiration_height\"\xea\x06\n\x07\x43hannel\x12\x16\n\x06\x61\x63tive\x18\x01 \x01(\x08R\x06\x61\x63tive\x12$\n\rremote_pubkey\x18\x02 \x01(\tR\rremote_pubkey\x12$\n\rchannel_point\x18\x03 \x01(\tR\rchannel_point\x12\x18\n\x07\x63han_id\x18\x04 \x01(\x04R\x07\x63han_id\x12\x1a\n\x08\x63\x61pacity\x18\x05 \x01(\x03R\x08\x63\x61pacity\x12$\n\rlocal_balance\x18\x06 \x01(\x03R\rlocal_balance\x12&\n\x0eremote_balance\x18\x07 \x01(\x03R\x0eremote_balance\x12\x1e\n\ncommit_fee\x18\x08 \x01(\x03R\ncommit_fee\x12$\n\rcommit_weight\x18\t \x01(\x03R\rcommit_weight\x12\x1e\n\nfee_per_kw\x18\n \x01(\x03R\nfee_per_kw\x12,\n\x11unsettled_balance\x18\x0b \x01(\x03R\x11unsettled_balance\x12\x30\n\x13total_satoshis_sent\x18\x0c \x01(\x03R\x13total_satoshis_sent\x12\x38\n\x17total_satoshis_received\x18\r \x01(\x03R\x17total_satoshis_received\x12 \n\x0bnum_updates\x18\x0e \x01(\x04R\x0bnum_updates\x12\x31\n\rpending_htlcs\x18\x0f \x03(\x0b\x32\x0b.lnrpc.HTLCR\rpending_htlcs\x12\x1c\n\tcsv_delay\x18\x10 \x01(\rR\tcsv_delay\x12\x18\n\x07private\x18\x11 \x01(\x08R\x07private\x12\x1c\n\tinitiator\x18\x12 \x01(\x08R\tinitiator\x12,\n\x11\x63han_status_flags\x18\x13 \x01(\tR\x11\x63han_status_flags\x12\x36\n\x16local_chan_reserve_sat\x18\x14 \x01(\x03R\x16local_chan_reserve_sat\x12\x38\n\x17remote_chan_reserve_sat\x18\x15 \x01(\x03R\x17remote_chan_reserve_sat\x12,\n\x11static_remote_key\x18\x16 \x01(\x08R\x11static_remote_key\"l\n\x13ListChannelsRequest\x12\x13\n\x0b\x61\x63tive_only\x18\x01 \x01(\x08\x12\x15\n\rinactive_only\x18\x02 \x01(\x08\x12\x13\n\x0bpublic_only\x18\x03 \x01(\x08\x12\x14\n\x0cprivate_only\x18\x04 \x01(\x08\"B\n\x14ListChannelsResponse\x12*\n\x08\x63hannels\x18\x0b \x03(\x0b\x32\x0e.lnrpc.ChannelR\x08\x63hannels\"\xb6\x04\n\x13\x43hannelCloseSummary\x12$\n\rchannel_point\x18\x01 \x01(\tR\rchannel_point\x12\x18\n\x07\x63han_id\x18\x02 \x01(\x04R\x07\x63han_id\x12\x1e\n\nchain_hash\x18\x03 \x01(\tR\nchain_hash\x12(\n\x0f\x63losing_tx_hash\x18\x04 \x01(\tR\x0f\x63losing_tx_hash\x12$\n\rremote_pubkey\x18\x05 \x01(\tR\rremote_pubkey\x12\x1a\n\x08\x63\x61pacity\x18\x06 \x01(\x03R\x08\x63\x61pacity\x12\"\n\x0c\x63lose_height\x18\x07 \x01(\rR\x0c\x63lose_height\x12(\n\x0fsettled_balance\x18\x08 \x01(\x03R\x0fsettled_balance\x12\x30\n\x13time_locked_balance\x18\t \x01(\x03R\x13time_locked_balance\x12\x46\n\nclose_type\x18\n \x01(\x0e\x32&.lnrpc.ChannelCloseSummary.ClosureTypeR\nclose_type\"\x8a\x01\n\x0b\x43losureType\x12\x15\n\x11\x43OOPERATIVE_CLOSE\x10\x00\x12\x15\n\x11LOCAL_FORCE_CLOSE\x10\x01\x12\x16\n\x12REMOTE_FORCE_CLOSE\x10\x02\x12\x10\n\x0c\x42REACH_CLOSE\x10\x03\x12\x14\n\x10\x46UNDING_CANCELED\x10\x04\x12\r\n\tABANDONED\x10\x05\"\x94\x01\n\x15\x43losedChannelsRequest\x12\x13\n\x0b\x63ooperative\x18\x01 \x01(\x08\x12\x13\n\x0blocal_force\x18\x02 \x01(\x08\x12\x14\n\x0cremote_force\x18\x03 \x01(\x08\x12\x0e\n\x06\x62reach\x18\x04 \x01(\x08\x12\x18\n\x10\x66unding_canceled\x18\x05 \x01(\x08\x12\x11\n\tabandoned\x18\x06 \x01(\x08\"P\n\x16\x43losedChannelsResponse\x12\x36\n\x08\x63hannels\x18\x01 \x03(\x0b\x32\x1a.lnrpc.ChannelCloseSummaryR\x08\x63hannels\"\xdf\x02\n\x04Peer\x12\x18\n\x07pub_key\x18\x01 \x01(\tR\x07pub_key\x12\x18\n\x07\x61\x64\x64ress\x18\x03 \x01(\tR\x07\x61\x64\x64ress\x12\x1e\n\nbytes_sent\x18\x04 \x01(\x04R\nbytes_sent\x12\x1e\n\nbytes_recv\x18\x05 \x01(\x04R\nbytes_recv\x12\x1a\n\x08sat_sent\x18\x06 \x01(\x03R\x08sat_sent\x12\x1a\n\x08sat_recv\x18\x07 \x01(\x03R\x08sat_recv\x12\x18\n\x07inbound\x18\x08 \x01(\x08R\x07inbound\x12\x1c\n\tping_time\x18\t \x01(\x03R\tping_time\x12\x32\n\tsync_type\x18\n \x01(\x0e\x32\x14.lnrpc.Peer.SyncTypeR\tsync_type\"?\n\x08SyncType\x12\x10\n\x0cUNKNOWN_SYNC\x10\x00\x12\x0f\n\x0b\x41\x43TIVE_SYNC\x10\x01\x12\x10\n\x0cPASSIVE_SYNC\x10\x02\"\x12\n\x10ListPeersRequest\"6\n\x11ListPeersResponse\x12!\n\x05peers\x18\x01 \x03(\x0b\x32\x0b.lnrpc.PeerR\x05peers\"\x10\n\x0eGetInfoRequest\"\xe7\x04\n\x0fGetInfoResponse\x12(\n\x0fidentity_pubkey\x18\x01 \x01(\tR\x0fidentity_pubkey\x12\x14\n\x05\x61lias\x18\x02 \x01(\tR\x05\x61lias\x12\x32\n\x14num_pending_channels\x18\x03 \x01(\rR\x14num_pending_channels\x12\x30\n\x13num_active_channels\x18\x04 \x01(\rR\x13num_active_channels\x12\x1c\n\tnum_peers\x18\x05 \x01(\rR\tnum_peers\x12\"\n\x0c\x62lock_height\x18\x06 \x01(\rR\x0c\x62lock_height\x12\x1e\n\nblock_hash\x18\x08 \x01(\tR\nblock_hash\x12(\n\x0fsynced_to_chain\x18\t \x01(\x08R\x0fsynced_to_chain\x12\x1c\n\x07testnet\x18\n \x01(\x08\x42\x02\x18\x01R\x07testnet\x12\x12\n\x04uris\x18\x0c \x03(\tR\x04uris\x12\x34\n\x15\x62\x65st_header_timestamp\x18\r \x01(\x03R\x15\x62\x65st_header_timestamp\x12\x18\n\x07version\x18\x0e \x01(\tR\x07version\x12\x34\n\x15num_inactive_channels\x18\x0f \x01(\rR\x15num_inactive_channels\x12$\n\x06\x63hains\x18\x10 \x03(\x0b\x32\x0c.lnrpc.ChainR\x06\x63hains\x12\x14\n\x05\x63olor\x18\x11 \x01(\tR\x05\x63olor\x12(\n\x0fsynced_to_graph\x18\x12 \x01(\x08R\x0fsynced_to_graphJ\x04\x08\x0b\x10\x0c\"7\n\x05\x43hain\x12\x14\n\x05\x63hain\x18\x01 \x01(\tR\x05\x63hain\x12\x18\n\x07network\x18\x02 \x01(\tR\x07network\"U\n\x12\x43onfirmationUpdate\x12\x11\n\tblock_sha\x18\x01 \x01(\x0c\x12\x14\n\x0c\x62lock_height\x18\x02 \x01(\x05\x12\x16\n\x0enum_confs_left\x18\x03 \x01(\r\"N\n\x11\x43hannelOpenUpdate\x12\x39\n\rchannel_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPointR\rchannel_point\"R\n\x12\x43hannelCloseUpdate\x12\"\n\x0c\x63losing_txid\x18\x01 \x01(\x0cR\x0c\x63losing_txid\x12\x18\n\x07success\x18\x02 \x01(\x08R\x07success\"{\n\x13\x43loseChannelRequest\x12*\n\rchannel_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\x12\x13\n\x0btarget_conf\x18\x03 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x04 \x01(\x03\"\x98\x01\n\x11\x43loseStatusUpdate\x12<\n\rclose_pending\x18\x01 \x01(\x0b\x32\x14.lnrpc.PendingUpdateH\x00R\rclose_pending\x12;\n\nchan_close\x18\x03 \x01(\x0b\x32\x19.lnrpc.ChannelCloseUpdateH\x00R\nchan_closeB\x08\n\x06update\"G\n\rPendingUpdate\x12\x12\n\x04txid\x18\x01 \x01(\x0cR\x04txid\x12\"\n\x0coutput_index\x18\x02 \x01(\rR\x0coutput_index\"\x99\x03\n\x12OpenChannelRequest\x12 \n\x0bnode_pubkey\x18\x02 \x01(\x0cR\x0bnode_pubkey\x12.\n\x12node_pubkey_string\x18\x03 \x01(\tR\x12node_pubkey_string\x12\x32\n\x14local_funding_amount\x18\x04 \x01(\x03R\x14local_funding_amount\x12\x1a\n\x08push_sat\x18\x05 \x01(\x03R\x08push_sat\x12\x13\n\x0btarget_conf\x18\x06 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x07 \x01(\x03\x12\x18\n\x07private\x18\x08 \x01(\x08R\x07private\x12$\n\rmin_htlc_msat\x18\t \x01(\x03R\rmin_htlc_msat\x12*\n\x10remote_csv_delay\x18\n \x01(\rR\x10remote_csv_delay\x12\x1c\n\tmin_confs\x18\x0b \x01(\x05R\tmin_confs\x12,\n\x11spend_unconfirmed\x18\x0c \x01(\x08R\x11spend_unconfirmed\"\x92\x01\n\x10OpenStatusUpdate\x12:\n\x0c\x63han_pending\x18\x01 \x01(\x0b\x32\x14.lnrpc.PendingUpdateH\x00R\x0c\x63han_pending\x12\x38\n\tchan_open\x18\x03 \x01(\x0b\x32\x18.lnrpc.ChannelOpenUpdateH\x00R\tchan_openB\x08\n\x06update\"\xcf\x01\n\x0bPendingHTLC\x12\x1a\n\x08incoming\x18\x01 \x01(\x08R\x08incoming\x12\x16\n\x06\x61mount\x18\x02 \x01(\x03R\x06\x61mount\x12\x1a\n\x08outpoint\x18\x03 \x01(\tR\x08outpoint\x12(\n\x0fmaturity_height\x18\x04 \x01(\rR\x0fmaturity_height\x12\x30\n\x13\x62locks_til_maturity\x18\x05 \x01(\x05R\x13\x62locks_til_maturity\x12\x14\n\x05stage\x18\x06 \x01(\rR\x05stage\"\x18\n\x16PendingChannelsRequest\"\x9c\r\n\x17PendingChannelsResponse\x12\x30\n\x13total_limbo_balance\x18\x01 \x01(\x03R\x13total_limbo_balance\x12g\n\x15pending_open_channels\x18\x02 \x03(\x0b\x32\x31.lnrpc.PendingChannelsResponse.PendingOpenChannelR\x15pending_open_channels\x12h\n\x18pending_closing_channels\x18\x03 \x03(\x0b\x32,.lnrpc.PendingChannelsResponse.ClosedChannelR\x18pending_closing_channels\x12y\n\x1epending_force_closing_channels\x18\x04 \x03(\x0b\x32\x31.lnrpc.PendingChannelsResponse.ForceClosedChannelR\x1epending_force_closing_channels\x12j\n\x16waiting_close_channels\x18\x05 \x03(\x0b\x32\x32.lnrpc.PendingChannelsResponse.WaitingCloseChannelR\x16waiting_close_channels\x1a\xbc\x02\n\x0ePendingChannel\x12(\n\x0fremote_node_pub\x18\x01 \x01(\tR\x0fremote_node_pub\x12$\n\rchannel_point\x18\x02 \x01(\tR\rchannel_point\x12\x1a\n\x08\x63\x61pacity\x18\x03 \x01(\x03R\x08\x63\x61pacity\x12$\n\rlocal_balance\x18\x04 \x01(\x03R\rlocal_balance\x12&\n\x0eremote_balance\x18\x05 \x01(\x03R\x0eremote_balance\x12\x36\n\x16local_chan_reserve_sat\x18\x06 \x01(\x03R\x16local_chan_reserve_sat\x12\x38\n\x17remote_chan_reserve_sat\x18\x07 \x01(\x03R\x17remote_chan_reserve_sat\x1a\xf5\x01\n\x12PendingOpenChannel\x12G\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannelR\x07\x63hannel\x12\x30\n\x13\x63onfirmation_height\x18\x02 \x01(\rR\x13\x63onfirmation_height\x12\x1e\n\ncommit_fee\x18\x04 \x01(\x03R\ncommit_fee\x12$\n\rcommit_weight\x18\x05 \x01(\x03R\rcommit_weight\x12\x1e\n\nfee_per_kw\x18\x06 \x01(\x03R\nfee_per_kw\x1a{\n\x13WaitingCloseChannel\x12>\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannel\x12$\n\rlimbo_balance\x18\x02 \x01(\x03R\rlimbo_balance\x1as\n\rClosedChannel\x12>\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannel\x12\"\n\x0c\x63losing_txid\x18\x02 \x01(\tR\x0c\x63losing_txid\x1a\xeb\x02\n\x12\x46orceClosedChannel\x12G\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannelR\x07\x63hannel\x12\"\n\x0c\x63losing_txid\x18\x02 \x01(\tR\x0c\x63losing_txid\x12$\n\rlimbo_balance\x18\x03 \x01(\x03R\rlimbo_balance\x12(\n\x0fmaturity_height\x18\x04 \x01(\rR\x0fmaturity_height\x12\x30\n\x13\x62locks_til_maturity\x18\x05 \x01(\x05R\x13\x62locks_til_maturity\x12,\n\x11recovered_balance\x18\x06 \x01(\x03R\x11recovered_balance\x12\x38\n\rpending_htlcs\x18\x08 \x03(\x0b\x32\x12.lnrpc.PendingHTLCR\rpending_htlcs\"\x1a\n\x18\x43hannelEventSubscription\"\xb5\x03\n\x12\x43hannelEventUpdate\x12\x34\n\x0copen_channel\x18\x01 \x01(\x0b\x32\x0e.lnrpc.ChannelH\x00R\x0copen_channel\x12\x44\n\x0e\x63losed_channel\x18\x02 \x01(\x0b\x32\x1a.lnrpc.ChannelCloseSummaryH\x00R\x0e\x63losed_channel\x12=\n\x0e\x61\x63tive_channel\x18\x03 \x01(\x0b\x32\x13.lnrpc.ChannelPointH\x00R\x0e\x61\x63tive_channel\x12\x41\n\x10inactive_channel\x18\x04 \x01(\x0b\x32\x13.lnrpc.ChannelPointH\x00R\x10inactive_channel\x12\x38\n\x04type\x18\x05 \x01(\x0e\x32$.lnrpc.ChannelEventUpdate.UpdateTypeR\x04type\"\\\n\nUpdateType\x12\x10\n\x0cOPEN_CHANNEL\x10\x00\x12\x12\n\x0e\x43LOSED_CHANNEL\x10\x01\x12\x12\n\x0e\x41\x43TIVE_CHANNEL\x10\x02\x12\x14\n\x10INACTIVE_CHANNEL\x10\x03\x42\t\n\x07\x63hannel\"\x16\n\x14WalletBalanceRequest\"\x9d\x01\n\x15WalletBalanceResponse\x12$\n\rtotal_balance\x18\x01 \x01(\x03R\rtotal_balance\x12,\n\x11\x63onfirmed_balance\x18\x02 \x01(\x03R\x11\x63onfirmed_balance\x12\x30\n\x13unconfirmed_balance\x18\x03 \x01(\x03R\x13unconfirmed_balance\"\x17\n\x15\x43hannelBalanceRequest\"f\n\x16\x43hannelBalanceResponse\x12\x18\n\x07\x62\x61lance\x18\x01 \x01(\x03R\x07\x62\x61lance\x12\x32\n\x14pending_open_balance\x18\x02 \x01(\x03R\x14pending_open_balance\"\x83\x03\n\x12QueryRoutesRequest\x12\x0f\n\x07pub_key\x18\x01 \x01(\t\x12\x0b\n\x03\x61mt\x18\x02 \x01(\x03\x12\x18\n\x10\x66inal_cltv_delta\x18\x04 \x01(\x05\x12\"\n\tfee_limit\x18\x05 \x01(\x0b\x32\x0f.lnrpc.FeeLimit\x12\x15\n\rignored_nodes\x18\x06 \x03(\x0c\x12-\n\rignored_edges\x18\x07 \x03(\x0b\x32\x12.lnrpc.EdgeLocatorB\x02\x18\x01\x12\x16\n\x0esource_pub_key\x18\x08 \x01(\t\x12\x1b\n\x13use_mission_control\x18\t \x01(\x08\x12&\n\rignored_pairs\x18\n \x03(\x0b\x32\x0f.lnrpc.NodePair\x12\x38\n\x08\x64\x65st_tlv\x18\x0b \x03(\x0b\x32&.lnrpc.QueryRoutesRequest.DestTlvEntry\x1a.\n\x0c\x44\x65stTlvEntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01J\x04\x08\x03\x10\x04\"$\n\x08NodePair\x12\x0c\n\x04\x66rom\x18\x01 \x01(\x0c\x12\n\n\x02to\x18\x02 \x01(\x0c\"<\n\x0b\x45\x64geLocator\x12\x12\n\nchannel_id\x18\x01 \x01(\x04\x12\x19\n\x11\x64irection_reverse\x18\x02 \x01(\x08\"_\n\x13QueryRoutesResponse\x12$\n\x06routes\x18\x01 \x03(\x0b\x32\x0c.lnrpc.RouteR\x06routes\x12\"\n\x0csuccess_prob\x18\x02 \x01(\x01R\x0csuccess_prob\"\x9a\x03\n\x03Hop\x12\x18\n\x07\x63han_id\x18\x01 \x01(\x04R\x07\x63han_id\x12$\n\rchan_capacity\x18\x02 \x01(\x03R\rchan_capacity\x12*\n\x0e\x61mt_to_forward\x18\x03 \x01(\x03\x42\x02\x18\x01R\x0e\x61mt_to_forward\x12\x14\n\x03\x66\x65\x65\x18\x04 \x01(\x03\x42\x02\x18\x01R\x03\x66\x65\x65\x12\x16\n\x06\x65xpiry\x18\x05 \x01(\rR\x06\x65xpiry\x12\x30\n\x13\x61mt_to_forward_msat\x18\x06 \x01(\x03R\x13\x61mt_to_forward_msat\x12\x1a\n\x08\x66\x65\x65_msat\x18\x07 \x01(\x03R\x08\x66\x65\x65_msat\x12\x18\n\x07pub_key\x18\x08 \x01(\tR\x07pub_key\x12 \n\x0btlv_payload\x18\t \x01(\x08R\x0btlv_payload\x12<\n\x0btlv_records\x18\n \x03(\x0b\x32\x1a.lnrpc.Hop.TlvRecordsEntryR\x0btlv_records\x1a\x31\n\x0fTlvRecordsEntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\"\xe9\x01\n\x05Route\x12(\n\x0ftotal_time_lock\x18\x01 \x01(\rR\x0ftotal_time_lock\x12\"\n\ntotal_fees\x18\x02 \x01(\x03\x42\x02\x18\x01R\ntotal_fees\x12 \n\ttotal_amt\x18\x03 \x01(\x03\x42\x02\x18\x01R\ttotal_amt\x12\x1e\n\x04hops\x18\x04 \x03(\x0b\x32\n.lnrpc.HopR\x04hops\x12(\n\x0ftotal_fees_msat\x18\x05 \x01(\x03R\x0ftotal_fees_msat\x12&\n\x0etotal_amt_msat\x18\x06 \x01(\x03R\x0etotal_amt_msat\"<\n\x0fNodeInfoRequest\x12\x0f\n\x07pub_key\x18\x01 \x01(\t\x12\x18\n\x10include_channels\x18\x02 \x01(\x08\"\xb0\x01\n\x08NodeInfo\x12(\n\x04node\x18\x01 \x01(\x0b\x32\x14.lnrpc.LightningNodeR\x04node\x12\"\n\x0cnum_channels\x18\x02 \x01(\rR\x0cnum_channels\x12&\n\x0etotal_capacity\x18\x03 \x01(\x03R\x0etotal_capacity\x12.\n\x08\x63hannels\x18\x04 \x03(\x0b\x32\x12.lnrpc.ChannelEdgeR\x08\x63hannels\"\xa9\x01\n\rLightningNode\x12 \n\x0blast_update\x18\x01 \x01(\rR\x0blast_update\x12\x18\n\x07pub_key\x18\x02 \x01(\tR\x07pub_key\x12\x14\n\x05\x61lias\x18\x03 \x01(\tR\x05\x61lias\x12\x30\n\taddresses\x18\x04 \x03(\x0b\x32\x12.lnrpc.NodeAddressR\taddresses\x12\x14\n\x05\x63olor\x18\x05 \x01(\tR\x05\x63olor\";\n\x0bNodeAddress\x12\x18\n\x07network\x18\x01 \x01(\tR\x07network\x12\x12\n\x04\x61\x64\x64r\x18\x02 \x01(\tR\x04\x61\x64\x64r\"\x91\x02\n\rRoutingPolicy\x12(\n\x0ftime_lock_delta\x18\x01 \x01(\rR\x0ftime_lock_delta\x12\x1a\n\x08min_htlc\x18\x02 \x01(\x03R\x08min_htlc\x12$\n\rfee_base_msat\x18\x03 \x01(\x03R\rfee_base_msat\x12\x30\n\x13\x66\x65\x65_rate_milli_msat\x18\x04 \x01(\x03R\x13\x66\x65\x65_rate_milli_msat\x12\x1a\n\x08\x64isabled\x18\x05 \x01(\x08R\x08\x64isabled\x12$\n\rmax_htlc_msat\x18\x06 \x01(\x04R\rmax_htlc_msat\x12 \n\x0blast_update\x18\x07 \x01(\rR\x0blast_update\"\xbf\x02\n\x0b\x43hannelEdge\x12\x1e\n\nchannel_id\x18\x01 \x01(\x04R\nchannel_id\x12\x1e\n\nchan_point\x18\x02 \x01(\tR\nchan_point\x12$\n\x0blast_update\x18\x03 \x01(\rB\x02\x18\x01R\x0blast_update\x12\x1c\n\tnode1_pub\x18\x04 \x01(\tR\tnode1_pub\x12\x1c\n\tnode2_pub\x18\x05 \x01(\tR\tnode2_pub\x12\x1a\n\x08\x63\x61pacity\x18\x06 \x01(\x03R\x08\x63\x61pacity\x12\x38\n\x0cnode1_policy\x18\x07 \x01(\x0b\x32\x14.lnrpc.RoutingPolicyR\x0cnode1_policy\x12\x38\n\x0cnode2_policy\x18\x08 \x01(\x0b\x32\x14.lnrpc.RoutingPolicyR\x0cnode2_policy\"G\n\x13\x43hannelGraphRequest\x12\x30\n\x13include_unannounced\x18\x01 \x01(\x08R\x13include_unannounced\"d\n\x0c\x43hannelGraph\x12*\n\x05nodes\x18\x01 \x03(\x0b\x32\x14.lnrpc.LightningNodeR\x05nodes\x12(\n\x05\x65\x64ges\x18\x02 \x03(\x0b\x32\x12.lnrpc.ChannelEdgeR\x05\x65\x64ges\"\"\n\x0f\x43hanInfoRequest\x12\x0f\n\x07\x63han_id\x18\x01 \x01(\x04\"\x14\n\x12NetworkInfoRequest\"\xe9\x03\n\x0bNetworkInfo\x12&\n\x0egraph_diameter\x18\x01 \x01(\rR\x0egraph_diameter\x12&\n\x0e\x61vg_out_degree\x18\x02 \x01(\x01R\x0e\x61vg_out_degree\x12&\n\x0emax_out_degree\x18\x03 \x01(\rR\x0emax_out_degree\x12\x1c\n\tnum_nodes\x18\x04 \x01(\rR\tnum_nodes\x12\"\n\x0cnum_channels\x18\x05 \x01(\rR\x0cnum_channels\x12\x36\n\x16total_network_capacity\x18\x06 \x01(\x03R\x16total_network_capacity\x12*\n\x10\x61vg_channel_size\x18\x07 \x01(\x01R\x10\x61vg_channel_size\x12*\n\x10min_channel_size\x18\x08 \x01(\x03R\x10min_channel_size\x12*\n\x10max_channel_size\x18\t \x01(\x03R\x10max_channel_size\x12\x38\n\x17median_channel_size_sat\x18\n \x01(\x03R\x17median_channel_size_sat\x12*\n\x10num_zombie_chans\x18\x0b \x01(\x04R\x10num_zombie_chans\"\r\n\x0bStopRequest\"\x0e\n\x0cStopResponse\"\x1b\n\x19GraphTopologySubscription\"\xa3\x01\n\x13GraphTopologyUpdate\x12\'\n\x0cnode_updates\x18\x01 \x03(\x0b\x32\x11.lnrpc.NodeUpdate\x12\x31\n\x0f\x63hannel_updates\x18\x02 \x03(\x0b\x32\x18.lnrpc.ChannelEdgeUpdate\x12\x30\n\x0c\x63losed_chans\x18\x03 \x03(\x0b\x32\x1a.lnrpc.ClosedChannelUpdate\"l\n\nNodeUpdate\x12\x11\n\taddresses\x18\x01 \x03(\t\x12\x14\n\x0cidentity_key\x18\x02 \x01(\t\x12\x17\n\x0fglobal_features\x18\x03 \x01(\x0c\x12\r\n\x05\x61lias\x18\x04 \x01(\t\x12\r\n\x05\x63olor\x18\x05 \x01(\t\"\xc0\x01\n\x11\x43hannelEdgeUpdate\x12\x0f\n\x07\x63han_id\x18\x01 \x01(\x04\x12\'\n\nchan_point\x18\x02 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\x12\x10\n\x08\x63\x61pacity\x18\x03 \x01(\x03\x12,\n\x0erouting_policy\x18\x04 \x01(\x0b\x32\x14.lnrpc.RoutingPolicy\x12\x18\n\x10\x61\x64vertising_node\x18\x05 \x01(\t\x12\x17\n\x0f\x63onnecting_node\x18\x06 \x01(\t\"x\n\x13\x43losedChannelUpdate\x12\x0f\n\x07\x63han_id\x18\x01 \x01(\x04\x12\x10\n\x08\x63\x61pacity\x18\x02 \x01(\x03\x12\x15\n\rclosed_height\x18\x03 \x01(\r\x12\'\n\nchan_point\x18\x04 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\"\xd3\x01\n\x07HopHint\x12\x18\n\x07node_id\x18\x01 \x01(\tR\x07node_id\x12\x18\n\x07\x63han_id\x18\x02 \x01(\x04R\x07\x63han_id\x12$\n\rfee_base_msat\x18\x03 \x01(\rR\rfee_base_msat\x12@\n\x1b\x66\x65\x65_proportional_millionths\x18\x04 \x01(\rR\x1b\x66\x65\x65_proportional_millionths\x12,\n\x11\x63ltv_expiry_delta\x18\x05 \x01(\rR\x11\x63ltv_expiry_delta\"9\n\tRouteHint\x12,\n\thop_hints\x18\x01 \x03(\x0b\x32\x0e.lnrpc.HopHintR\thop_hints\"\xbf\x06\n\x07Invoice\x12\x12\n\x04memo\x18\x01 \x01(\tR\x04memo\x12\x1c\n\x07receipt\x18\x02 \x01(\x0c\x42\x02\x18\x01R\x07receipt\x12\x1e\n\nr_preimage\x18\x03 \x01(\x0cR\nr_preimage\x12\x16\n\x06r_hash\x18\x04 \x01(\x0cR\x06r_hash\x12\x14\n\x05value\x18\x05 \x01(\x03R\x05value\x12\x1c\n\x07settled\x18\x06 \x01(\x08\x42\x02\x18\x01R\x07settled\x12$\n\rcreation_date\x18\x07 \x01(\x03R\rcreation_date\x12 \n\x0bsettle_date\x18\x08 \x01(\x03R\x0bsettle_date\x12(\n\x0fpayment_request\x18\t \x01(\tR\x0fpayment_request\x12*\n\x10\x64\x65scription_hash\x18\n \x01(\x0cR\x10\x64\x65scription_hash\x12\x16\n\x06\x65xpiry\x18\x0b \x01(\x03R\x06\x65xpiry\x12$\n\rfallback_addr\x18\x0c \x01(\tR\rfallback_addr\x12 \n\x0b\x63ltv_expiry\x18\r \x01(\x04R\x0b\x63ltv_expiry\x12\x32\n\x0broute_hints\x18\x0e \x03(\x0b\x32\x10.lnrpc.RouteHintR\x0broute_hints\x12\x18\n\x07private\x18\x0f \x01(\x08R\x07private\x12\x1c\n\tadd_index\x18\x10 \x01(\x04R\tadd_index\x12\"\n\x0csettle_index\x18\x11 \x01(\x04R\x0csettle_index\x12\x1e\n\x08\x61mt_paid\x18\x12 \x01(\x03\x42\x02\x18\x01R\x08\x61mt_paid\x12\"\n\x0c\x61mt_paid_sat\x18\x13 \x01(\x03R\x0c\x61mt_paid_sat\x12$\n\ramt_paid_msat\x18\x14 \x01(\x03R\ramt_paid_msat\x12\x31\n\x05state\x18\x15 \x01(\x0e\x32\x1b.lnrpc.Invoice.InvoiceStateR\x05state\x12(\n\x05htlcs\x18\x16 \x03(\x0b\x32\x12.lnrpc.InvoiceHTLCR\x05htlcs\"A\n\x0cInvoiceState\x12\x08\n\x04OPEN\x10\x00\x12\x0b\n\x07SETTLED\x10\x01\x12\x0c\n\x08\x43\x41NCELED\x10\x02\x12\x0c\n\x08\x41\x43\x43\x45PTED\x10\x03\"\xa4\x02\n\x0bInvoiceHTLC\x12\x18\n\x07\x63han_id\x18\x01 \x01(\x04R\x07\x63han_id\x12\x1e\n\nhtlc_index\x18\x02 \x01(\x04R\nhtlc_index\x12\x1a\n\x08\x61mt_msat\x18\x03 \x01(\x04R\x08\x61mt_msat\x12$\n\raccept_height\x18\x04 \x01(\x05R\raccept_height\x12 \n\x0b\x61\x63\x63\x65pt_time\x18\x05 \x01(\x03R\x0b\x61\x63\x63\x65pt_time\x12\"\n\x0cresolve_time\x18\x06 \x01(\x03R\x0cresolve_time\x12$\n\rexpiry_height\x18\x07 \x01(\x05R\rexpiry_height\x12-\n\x05state\x18\x08 \x01(\x0e\x32\x17.lnrpc.InvoiceHTLCStateR\x05state\"t\n\x12\x41\x64\x64InvoiceResponse\x12\x16\n\x06r_hash\x18\x01 \x01(\x0cR\x06r_hash\x12(\n\x0fpayment_request\x18\x02 \x01(\tR\x0fpayment_request\x12\x1c\n\tadd_index\x18\x10 \x01(\x04R\tadd_index\"E\n\x0bPaymentHash\x12\x1e\n\nr_hash_str\x18\x01 \x01(\tR\nr_hash_str\x12\x16\n\x06r_hash\x18\x02 \x01(\x0cR\x06r_hash\"\xa4\x01\n\x12ListInvoiceRequest\x12\"\n\x0cpending_only\x18\x01 \x01(\x08R\x0cpending_only\x12\"\n\x0cindex_offset\x18\x04 \x01(\x04R\x0cindex_offset\x12*\n\x10num_max_invoices\x18\x05 \x01(\x04R\x10num_max_invoices\x12\x1a\n\x08reversed\x18\x06 \x01(\x08R\x08reversed\"\x9f\x01\n\x13ListInvoiceResponse\x12*\n\x08invoices\x18\x01 \x03(\x0b\x32\x0e.lnrpc.InvoiceR\x08invoices\x12,\n\x11last_index_offset\x18\x02 \x01(\x04R\x11last_index_offset\x12.\n\x12\x66irst_index_offset\x18\x03 \x01(\x04R\x12\x66irst_index_offset\"W\n\x13InvoiceSubscription\x12\x1c\n\tadd_index\x18\x01 \x01(\x04R\tadd_index\x12\"\n\x0csettle_index\x18\x02 \x01(\x04R\x0csettle_index\"\xdf\x03\n\x07Payment\x12\"\n\x0cpayment_hash\x18\x01 \x01(\tR\x0cpayment_hash\x12\x18\n\x05value\x18\x02 \x01(\x03\x42\x02\x18\x01R\x05value\x12$\n\rcreation_date\x18\x03 \x01(\x03R\rcreation_date\x12\x12\n\x04path\x18\x04 \x03(\tR\x04path\x12\x14\n\x03\x66\x65\x65\x18\x05 \x01(\x03\x42\x02\x18\x01R\x03\x66\x65\x65\x12*\n\x10payment_preimage\x18\x06 \x01(\tR\x10payment_preimage\x12\x1c\n\tvalue_sat\x18\x07 \x01(\x03R\tvalue_sat\x12\x1e\n\nvalue_msat\x18\x08 \x01(\x03R\nvalue_msat\x12(\n\x0fpayment_request\x18\t \x01(\tR\x0fpayment_request\x12\x34\n\x06status\x18\n \x01(\x0e\x32\x1c.lnrpc.Payment.PaymentStatusR\x06status\x12\x18\n\x07\x66\x65\x65_sat\x18\x0b \x01(\x03R\x07\x66\x65\x65_sat\x12\x1a\n\x08\x66\x65\x65_msat\x18\x0c \x01(\x03R\x08\x66\x65\x65_msat\"F\n\rPaymentStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\r\n\tIN_FLIGHT\x10\x01\x12\r\n\tSUCCEEDED\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\"1\n\x13ListPaymentsRequest\x12\x1a\n\x12include_incomplete\x18\x01 \x01(\x08\"B\n\x14ListPaymentsResponse\x12*\n\x08payments\x18\x01 \x03(\x0b\x32\x0e.lnrpc.PaymentR\x08payments\"\x1a\n\x18\x44\x65leteAllPaymentsRequest\"\x1b\n\x19\x44\x65leteAllPaymentsResponse\"C\n\x15\x41\x62\x61ndonChannelRequest\x12*\n\rchannel_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\"\x18\n\x16\x41\x62\x61ndonChannelResponse\"5\n\x11\x44\x65\x62ugLevelRequest\x12\x0c\n\x04show\x18\x01 \x01(\x08\x12\x12\n\nlevel_spec\x18\x02 \x01(\t\"6\n\x12\x44\x65\x62ugLevelResponse\x12 \n\x0bsub_systems\x18\x01 \x01(\tR\x0bsub_systems\"\x1f\n\x0cPayReqString\x12\x0f\n\x07pay_req\x18\x01 \x01(\t\"\xf2\x02\n\x06PayReq\x12 \n\x0b\x64\x65stination\x18\x01 \x01(\tR\x0b\x64\x65stination\x12\"\n\x0cpayment_hash\x18\x02 \x01(\tR\x0cpayment_hash\x12\"\n\x0cnum_satoshis\x18\x03 \x01(\x03R\x0cnum_satoshis\x12\x1c\n\ttimestamp\x18\x04 \x01(\x03R\ttimestamp\x12\x16\n\x06\x65xpiry\x18\x05 \x01(\x03R\x06\x65xpiry\x12 \n\x0b\x64\x65scription\x18\x06 \x01(\tR\x0b\x64\x65scription\x12*\n\x10\x64\x65scription_hash\x18\x07 \x01(\tR\x10\x64\x65scription_hash\x12$\n\rfallback_addr\x18\x08 \x01(\tR\rfallback_addr\x12 \n\x0b\x63ltv_expiry\x18\t \x01(\x03R\x0b\x63ltv_expiry\x12\x32\n\x0broute_hints\x18\n \x03(\x0b\x32\x10.lnrpc.RouteHintR\x0broute_hints\"\x12\n\x10\x46\x65\x65ReportRequest\"\x99\x01\n\x10\x43hannelFeeReport\x12!\n\nchan_point\x18\x01 \x01(\tR\rchannel_point\x12$\n\rbase_fee_msat\x18\x02 \x01(\x03R\rbase_fee_msat\x12 \n\x0b\x66\x65\x65_per_mil\x18\x03 \x01(\x03R\x0b\x66\x65\x65_per_mil\x12\x1a\n\x08\x66\x65\x65_rate\x18\x04 \x01(\x01R\x08\x66\x65\x65_rate\"\xbc\x01\n\x11\x46\x65\x65ReportResponse\x12;\n\x0c\x63hannel_fees\x18\x01 \x03(\x0b\x32\x17.lnrpc.ChannelFeeReportR\x0c\x63hannel_fees\x12 \n\x0b\x64\x61y_fee_sum\x18\x02 \x01(\x04R\x0b\x64\x61y_fee_sum\x12\"\n\x0cweek_fee_sum\x18\x03 \x01(\x04R\x0cweek_fee_sum\x12$\n\rmonth_fee_sum\x18\x04 \x01(\x04R\rmonth_fee_sum\"\x81\x02\n\x13PolicyUpdateRequest\x12\x18\n\x06global\x18\x01 \x01(\x08H\x00R\x06global\x12\x35\n\nchan_point\x18\x02 \x01(\x0b\x32\x13.lnrpc.ChannelPointH\x00R\nchan_point\x12$\n\rbase_fee_msat\x18\x03 \x01(\x03R\rbase_fee_msat\x12\x1a\n\x08\x66\x65\x65_rate\x18\x04 \x01(\x01R\x08\x66\x65\x65_rate\x12(\n\x0ftime_lock_delta\x18\x05 \x01(\rR\x0ftime_lock_delta\x12$\n\rmax_htlc_msat\x18\x06 \x01(\x04R\rmax_htlc_msatB\x07\n\x05scope\"\x16\n\x14PolicyUpdateResponse\"\xa2\x01\n\x18\x46orwardingHistoryRequest\x12\x1e\n\nstart_time\x18\x01 \x01(\x04R\nstart_time\x12\x1a\n\x08\x65nd_time\x18\x02 \x01(\x04R\x08\x65nd_time\x12\"\n\x0cindex_offset\x18\x03 \x01(\rR\x0cindex_offset\x12&\n\x0enum_max_events\x18\x04 \x01(\rR\x0enum_max_events\"\xd1\x01\n\x0f\x46orwardingEvent\x12\x1c\n\ttimestamp\x18\x01 \x01(\x04R\ttimestamp\x12\x1e\n\nchan_id_in\x18\x02 \x01(\x04R\nchan_id_in\x12 \n\x0b\x63han_id_out\x18\x04 \x01(\x04R\x0b\x63han_id_out\x12\x16\n\x06\x61mt_in\x18\x05 \x01(\x04R\x06\x61mt_in\x12\x18\n\x07\x61mt_out\x18\x06 \x01(\x04R\x07\x61mt_out\x12\x10\n\x03\x66\x65\x65\x18\x07 \x01(\x04R\x03\x66\x65\x65\x12\x1a\n\x08\x66\x65\x65_msat\x18\x08 \x01(\x04R\x08\x66\x65\x65_msat\"\x8f\x01\n\x19\x46orwardingHistoryResponse\x12\x44\n\x11\x66orwarding_events\x18\x01 \x03(\x0b\x32\x16.lnrpc.ForwardingEventR\x11\x66orwarding_events\x12,\n\x11last_offset_index\x18\x02 \x01(\rR\x11last_offset_index\"E\n\x1a\x45xportChannelBackupRequest\x12\'\n\nchan_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\"f\n\rChannelBackup\x12\x33\n\nchan_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPointR\nchan_point\x12 \n\x0b\x63han_backup\x18\x02 \x01(\x0cR\x0b\x63han_backup\"v\n\x0fMultiChanBackup\x12\x35\n\x0b\x63han_points\x18\x01 \x03(\x0b\x32\x13.lnrpc.ChannelPointR\x0b\x63han_points\x12,\n\x11multi_chan_backup\x18\x02 \x01(\x0cR\x11multi_chan_backup\"\x19\n\x17\x43hanBackupExportRequest\"\xa3\x01\n\x12\x43hanBackupSnapshot\x12G\n\x13single_chan_backups\x18\x01 \x01(\x0b\x32\x15.lnrpc.ChannelBackupsR\x13single_chan_backups\x12\x44\n\x11multi_chan_backup\x18\x02 \x01(\x0b\x32\x16.lnrpc.MultiChanBackupR\x11multi_chan_backup\"J\n\x0e\x43hannelBackups\x12\x38\n\x0c\x63han_backups\x18\x01 \x03(\x0b\x32\x14.lnrpc.ChannelBackupR\x0c\x63han_backups\"\x91\x01\n\x18RestoreChanBackupRequest\x12;\n\x0c\x63han_backups\x18\x01 \x01(\x0b\x32\x15.lnrpc.ChannelBackupsH\x00R\x0c\x63han_backups\x12.\n\x11multi_chan_backup\x18\x02 \x01(\x0cH\x00R\x11multi_chan_backupB\x08\n\x06\x62\x61\x63kup\"\x17\n\x15RestoreBackupResponse\"\x1b\n\x19\x43hannelBackupSubscription\"\x1a\n\x18VerifyChanBackupResponse*}\n\x0b\x41\x64\x64ressType\x12\x17\n\x13WITNESS_PUBKEY_HASH\x10\x00\x12\x16\n\x12NESTED_PUBKEY_HASH\x10\x01\x12\x1e\n\x1aUNUSED_WITNESS_PUBKEY_HASH\x10\x02\x12\x1d\n\x19UNUSED_NESTED_PUBKEY_HASH\x10\x03*<\n\x10InvoiceHTLCState\x12\x0c\n\x08\x41\x43\x43\x45PTED\x10\x00\x12\x0b\n\x07SETTLED\x10\x01\x12\r\n\tCANCELLED\x10\x02\x32\x91\x03\n\x0eWalletUnlocker\x12M\n\x07GenSeed\x12\x15.lnrpc.GenSeedRequest\x1a\x16.lnrpc.GenSeedResponse\"\x13\x82\xd3\xe4\x93\x02\r\x12\x0b/v1/genseed\x12\\\n\nInitWallet\x12\x18.lnrpc.InitWalletRequest\x1a\x19.lnrpc.InitWalletResponse\"\x19\x82\xd3\xe4\x93\x02\x13\"\x0e/v1/initwallet:\x01*\x12\x64\n\x0cUnlockWallet\x12\x1a.lnrpc.UnlockWalletRequest\x1a\x1b.lnrpc.UnlockWalletResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v1/unlockwallet:\x01*\x12l\n\x0e\x43hangePassword\x12\x1c.lnrpc.ChangePasswordRequest\x1a\x1d.lnrpc.ChangePasswordResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\"\x12/v1/changepassword:\x01*2\xe8&\n\tLightning\x12j\n\rWalletBalance\x12\x1b.lnrpc.WalletBalanceRequest\x1a\x1c.lnrpc.WalletBalanceResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/v1/balance/blockchain\x12k\n\x0e\x43hannelBalance\x12\x1c.lnrpc.ChannelBalanceRequest\x1a\x1d.lnrpc.ChannelBalanceResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/balance/channels\x12\x65\n\x0fGetTransactions\x12\x1d.lnrpc.GetTransactionsRequest\x1a\x19.lnrpc.TransactionDetails\"\x18\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/transactions\x12\x62\n\x0b\x45stimateFee\x12\x19.lnrpc.EstimateFeeRequest\x1a\x1a.lnrpc.EstimateFeeResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/transactions/fee\x12[\n\tSendCoins\x12\x17.lnrpc.SendCoinsRequest\x1a\x18.lnrpc.SendCoinsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v1/transactions:\x01*\x12W\n\x0bListUnspent\x12\x19.lnrpc.ListUnspentRequest\x1a\x1a.lnrpc.ListUnspentResponse\"\x11\x82\xd3\xe4\x93\x02\x0b\x12\t/v1/utxos\x12L\n\x15SubscribeTransactions\x12\x1d.lnrpc.GetTransactionsRequest\x1a\x12.lnrpc.Transaction0\x01\x12;\n\x08SendMany\x12\x16.lnrpc.SendManyRequest\x1a\x17.lnrpc.SendManyResponse\x12Y\n\nNewAddress\x12\x18.lnrpc.NewAddressRequest\x1a\x19.lnrpc.NewAddressResponse\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/newaddress\x12`\n\x0bSignMessage\x12\x19.lnrpc.SignMessageRequest\x1a\x1a.lnrpc.SignMessageResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\"\x0f/v1/signmessage:\x01*\x12h\n\rVerifyMessage\x12\x1b.lnrpc.VerifyMessageRequest\x1a\x1c.lnrpc.VerifyMessageResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/verifymessage:\x01*\x12Z\n\x0b\x43onnectPeer\x12\x19.lnrpc.ConnectPeerRequest\x1a\x1a.lnrpc.ConnectPeerResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\"\t/v1/peers:\x01*\x12j\n\x0e\x44isconnectPeer\x12\x1c.lnrpc.DisconnectPeerRequest\x1a\x1d.lnrpc.DisconnectPeerResponse\"\x1b\x82\xd3\xe4\x93\x02\x15*\x13/v1/peers/{pub_key}\x12Q\n\tListPeers\x12\x17.lnrpc.ListPeersRequest\x1a\x18.lnrpc.ListPeersResponse\"\x11\x82\xd3\xe4\x93\x02\x0b\x12\t/v1/peers\x12M\n\x07GetInfo\x12\x15.lnrpc.GetInfoRequest\x1a\x16.lnrpc.GetInfoResponse\"\x13\x82\xd3\xe4\x93\x02\r\x12\x0b/v1/getinfo\x12n\n\x0fPendingChannels\x12\x1d.lnrpc.PendingChannelsRequest\x1a\x1e.lnrpc.PendingChannelsResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/channels/pending\x12]\n\x0cListChannels\x12\x1a.lnrpc.ListChannelsRequest\x1a\x1b.lnrpc.ListChannelsResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/v1/channels\x12V\n\x16SubscribeChannelEvents\x12\x1f.lnrpc.ChannelEventSubscription\x1a\x19.lnrpc.ChannelEventUpdate0\x01\x12j\n\x0e\x43losedChannels\x12\x1c.lnrpc.ClosedChannelsRequest\x1a\x1d.lnrpc.ClosedChannelsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/channels/closed\x12Z\n\x0fOpenChannelSync\x12\x19.lnrpc.OpenChannelRequest\x1a\x13.lnrpc.ChannelPoint\"\x17\x82\xd3\xe4\x93\x02\x11\"\x0c/v1/channels:\x01*\x12\x43\n\x0bOpenChannel\x12\x19.lnrpc.OpenChannelRequest\x1a\x17.lnrpc.OpenStatusUpdate0\x01\x12P\n\x0f\x43hannelAcceptor\x12\x1c.lnrpc.ChannelAcceptResponse\x1a\x1b.lnrpc.ChannelAcceptRequest(\x01\x30\x01\x12\x9a\x01\n\x0c\x43loseChannel\x12\x1a.lnrpc.CloseChannelRequest\x1a\x18.lnrpc.CloseStatusUpdate\"R\x82\xd3\xe4\x93\x02L*J/v1/channels/{channel_point.funding_txid_str}/{channel_point.output_index}0\x01\x12\xa9\x01\n\x0e\x41\x62\x61ndonChannel\x12\x1c.lnrpc.AbandonChannelRequest\x1a\x1d.lnrpc.AbandonChannelResponse\"Z\x82\xd3\xe4\x93\x02T*R/v1/channels/abandon/{channel_point.funding_txid_str}/{channel_point.output_index}\x12:\n\x0bSendPayment\x12\x12.lnrpc.SendRequest\x1a\x13.lnrpc.SendResponse(\x01\x30\x01\x12`\n\x0fSendPaymentSync\x12\x12.lnrpc.SendRequest\x1a\x13.lnrpc.SendResponse\"$\x82\xd3\xe4\x93\x02\x1e\"\x19/v1/channels/transactions:\x01*\x12\x41\n\x0bSendToRoute\x12\x19.lnrpc.SendToRouteRequest\x1a\x13.lnrpc.SendResponse(\x01\x30\x01\x12m\n\x0fSendToRouteSync\x12\x19.lnrpc.SendToRouteRequest\x1a\x13.lnrpc.SendResponse\"*\x82\xd3\xe4\x93\x02$\"\x1f/v1/channels/transactions/route:\x01*\x12P\n\nAddInvoice\x12\x0e.lnrpc.Invoice\x1a\x19.lnrpc.AddInvoiceResponse\"\x17\x82\xd3\xe4\x93\x02\x11\"\x0c/v1/invoices:\x01*\x12[\n\x0cListInvoices\x12\x19.lnrpc.ListInvoiceRequest\x1a\x1a.lnrpc.ListInvoiceResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/v1/invoices\x12U\n\rLookupInvoice\x12\x12.lnrpc.PaymentHash\x1a\x0e.lnrpc.Invoice\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/invoice/{r_hash_str}\x12\x61\n\x11SubscribeInvoices\x12\x1a.lnrpc.InvoiceSubscription\x1a\x0e.lnrpc.Invoice\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/v1/invoices/subscribe0\x01\x12P\n\x0c\x44\x65\x63odePayReq\x12\x13.lnrpc.PayReqString\x1a\r.lnrpc.PayReq\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/payreq/{pay_req}\x12]\n\x0cListPayments\x12\x1a.lnrpc.ListPaymentsRequest\x1a\x1b.lnrpc.ListPaymentsResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/v1/payments\x12l\n\x11\x44\x65leteAllPayments\x12\x1f.lnrpc.DeleteAllPaymentsRequest\x1a .lnrpc.DeleteAllPaymentsResponse\"\x14\x82\xd3\xe4\x93\x02\x0e*\x0c/v1/payments\x12S\n\rDescribeGraph\x12\x1a.lnrpc.ChannelGraphRequest\x1a\x13.lnrpc.ChannelGraph\"\x11\x82\xd3\xe4\x93\x02\x0b\x12\t/v1/graph\x12[\n\x0bGetChanInfo\x12\x16.lnrpc.ChanInfoRequest\x1a\x12.lnrpc.ChannelEdge\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/graph/edge/{chan_id}\x12X\n\x0bGetNodeInfo\x12\x16.lnrpc.NodeInfoRequest\x1a\x0f.lnrpc.NodeInfo\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/graph/node/{pub_key}\x12n\n\x0bQueryRoutes\x12\x19.lnrpc.QueryRoutesRequest\x1a\x1a.lnrpc.QueryRoutesResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v1/graph/routes/{pub_key}/{amt}\x12W\n\x0eGetNetworkInfo\x12\x19.lnrpc.NetworkInfoRequest\x1a\x12.lnrpc.NetworkInfo\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/graph/info\x12\x35\n\nStopDaemon\x12\x12.lnrpc.StopRequest\x1a\x13.lnrpc.StopResponse\x12W\n\x15SubscribeChannelGraph\x12 .lnrpc.GraphTopologySubscription\x1a\x1a.lnrpc.GraphTopologyUpdate0\x01\x12\x41\n\nDebugLevel\x12\x18.lnrpc.DebugLevelRequest\x1a\x19.lnrpc.DebugLevelResponse\x12P\n\tFeeReport\x12\x17.lnrpc.FeeReportRequest\x1a\x18.lnrpc.FeeReportResponse\"\x10\x82\xd3\xe4\x93\x02\n\x12\x08/v1/fees\x12i\n\x13UpdateChannelPolicy\x12\x1a.lnrpc.PolicyUpdateRequest\x1a\x1b.lnrpc.PolicyUpdateResponse\"\x19\x82\xd3\xe4\x93\x02\x13\"\x0e/v1/chanpolicy:\x01*\x12m\n\x11\x46orwardingHistory\x12\x1f.lnrpc.ForwardingHistoryRequest\x1a .lnrpc.ForwardingHistoryResponse\"\x15\x82\xd3\xe4\x93\x02\x0f\"\n/v1/switch:\x01*\x12\xa3\x01\n\x13\x45xportChannelBackup\x12!.lnrpc.ExportChannelBackupRequest\x1a\x14.lnrpc.ChannelBackup\"S\x82\xd3\xe4\x93\x02M\x12K/v1/channels/backup/{chan_point.funding_txid_str}/{chan_point.output_index}\x12q\n\x17\x45xportAllChannelBackups\x12\x1e.lnrpc.ChanBackupExportRequest\x1a\x19.lnrpc.ChanBackupSnapshot\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/channels/backup\x12u\n\x10VerifyChanBackup\x12\x19.lnrpc.ChanBackupSnapshot\x1a\x1f.lnrpc.VerifyChanBackupResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v1/channels/backup/verify:\x01*\x12~\n\x15RestoreChannelBackups\x12\x1f.lnrpc.RestoreChanBackupRequest\x1a\x1c.lnrpc.RestoreBackupResponse\"&\x82\xd3\xe4\x93\x02 \"\x1b/v1/channels/backup/restore:\x01*\x12Z\n\x17SubscribeChannelBackups\x12 .lnrpc.ChannelBackupSubscription\x1a\x19.lnrpc.ChanBackupSnapshot\"\x00\x30\x01\x42\'Z%github.com/lightningnetwork/lnd/lnrpcb\x06proto3')
+  serialized_pb=_b('\n\trpc.proto\x12\x05lnrpc\x1a\x1cgoogle/api/annotations.proto\"A\n\x0eGenSeedRequest\x12\x19\n\x11\x61\x65zeed_passphrase\x18\x01 \x01(\x0c\x12\x14\n\x0cseed_entropy\x18\x02 \x01(\x0c\"H\n\x0fGenSeedResponse\x12\x1c\n\x14\x63ipher_seed_mnemonic\x18\x01 \x03(\t\x12\x17\n\x0f\x65nciphered_seed\x18\x02 \x01(\x0c\"\xb2\x01\n\x11InitWalletRequest\x12\x17\n\x0fwallet_password\x18\x01 \x01(\x0c\x12\x1c\n\x14\x63ipher_seed_mnemonic\x18\x02 \x03(\t\x12\x19\n\x11\x61\x65zeed_passphrase\x18\x03 \x01(\x0c\x12\x17\n\x0frecovery_window\x18\x04 \x01(\x05\x12\x32\n\x0f\x63hannel_backups\x18\x05 \x01(\x0b\x32\x19.lnrpc.ChanBackupSnapshot\"\x14\n\x12InitWalletResponse\"{\n\x13UnlockWalletRequest\x12\x17\n\x0fwallet_password\x18\x01 \x01(\x0c\x12\x17\n\x0frecovery_window\x18\x02 \x01(\x05\x12\x32\n\x0f\x63hannel_backups\x18\x03 \x01(\x0b\x32\x19.lnrpc.ChanBackupSnapshot\"\x16\n\x14UnlockWalletResponse\"G\n\x15\x43hangePasswordRequest\x12\x18\n\x10\x63urrent_password\x18\x01 \x01(\x0c\x12\x14\n\x0cnew_password\x18\x02 \x01(\x0c\"\x18\n\x16\x43hangePasswordResponse\"\xe1\x01\n\x04Utxo\x12.\n\x04type\x18\x01 \x01(\x0e\x32\x12.lnrpc.AddressTypeR\x0c\x61\x64\x64ress_type\x12\x18\n\x07\x61\x64\x64ress\x18\x02 \x01(\tR\x07\x61\x64\x64ress\x12\x1e\n\namount_sat\x18\x03 \x01(\x03R\namount_sat\x12\x1c\n\tpk_script\x18\x04 \x01(\tR\tpk_script\x12+\n\x08outpoint\x18\x05 \x01(\x0b\x32\x0f.lnrpc.OutPointR\x08outpoint\x12$\n\rconfirmations\x18\x06 \x01(\x03R\rconfirmations\"\xb9\x02\n\x0bTransaction\x12\x18\n\x07tx_hash\x18\x01 \x01(\tR\x07tx_hash\x12\x16\n\x06\x61mount\x18\x02 \x01(\x03R\x06\x61mount\x12,\n\x11num_confirmations\x18\x03 \x01(\x05R\x11num_confirmations\x12\x1e\n\nblock_hash\x18\x04 \x01(\tR\nblock_hash\x12\"\n\x0c\x62lock_height\x18\x05 \x01(\x05R\x0c\x62lock_height\x12\x1e\n\ntime_stamp\x18\x06 \x01(\x03R\ntime_stamp\x12\x1e\n\ntotal_fees\x18\x07 \x01(\x03R\ntotal_fees\x12&\n\x0e\x64\x65st_addresses\x18\x08 \x03(\tR\x0e\x64\x65st_addresses\x12\x1e\n\nraw_tx_hex\x18\t \x01(\tR\nraw_tx_hex\"\x18\n\x16GetTransactionsRequest\"L\n\x12TransactionDetails\x12\x36\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x12.lnrpc.TransactionR\x0ctransactions\"7\n\x08\x46\x65\x65Limit\x12\x0f\n\x05\x66ixed\x18\x01 \x01(\x03H\x00\x12\x11\n\x07percent\x18\x02 \x01(\x03H\x00\x42\x07\n\x05limit\"\xdc\x02\n\x0bSendRequest\x12\x0c\n\x04\x64\x65st\x18\x01 \x01(\x0c\x12\x13\n\x0b\x64\x65st_string\x18\x02 \x01(\t\x12\x0b\n\x03\x61mt\x18\x03 \x01(\x03\x12\x14\n\x0cpayment_hash\x18\x04 \x01(\x0c\x12\x1b\n\x13payment_hash_string\x18\x05 \x01(\t\x12\x17\n\x0fpayment_request\x18\x06 \x01(\t\x12\x18\n\x10\x66inal_cltv_delta\x18\x07 \x01(\x05\x12\"\n\tfee_limit\x18\x08 \x01(\x0b\x32\x0f.lnrpc.FeeLimit\x12\x1c\n\x10outgoing_chan_id\x18\t \x01(\x04\x42\x02\x30\x01\x12\x12\n\ncltv_limit\x18\n \x01(\r\x12\x31\n\x08\x64\x65st_tlv\x18\x0b \x03(\x0b\x32\x1f.lnrpc.SendRequest.DestTlvEntry\x1a.\n\x0c\x44\x65stTlvEntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\"\xb8\x01\n\x0cSendResponse\x12$\n\rpayment_error\x18\x01 \x01(\tR\rpayment_error\x12*\n\x10payment_preimage\x18\x02 \x01(\x0cR\x10payment_preimage\x12\x32\n\rpayment_route\x18\x03 \x01(\x0b\x32\x0c.lnrpc.RouteR\rpayment_route\x12\"\n\x0cpayment_hash\x18\x04 \x01(\x0cR\x0cpayment_hash\"j\n\x12SendToRouteRequest\x12\x14\n\x0cpayment_hash\x18\x01 \x01(\x0c\x12\x1b\n\x13payment_hash_string\x18\x02 \x01(\t\x12\x1b\n\x05route\x18\x04 \x01(\x0b\x32\x0c.lnrpc.RouteJ\x04\x08\x03\x10\x04\"\xb5\x02\n\x14\x43hannelAcceptRequest\x12\x13\n\x0bnode_pubkey\x18\x01 \x01(\x0c\x12\x12\n\nchain_hash\x18\x02 \x01(\x0c\x12\x17\n\x0fpending_chan_id\x18\x03 \x01(\x0c\x12\x13\n\x0b\x66unding_amt\x18\x04 \x01(\x04\x12\x10\n\x08push_amt\x18\x05 \x01(\x04\x12\x12\n\ndust_limit\x18\x06 \x01(\x04\x12\x1b\n\x13max_value_in_flight\x18\x07 \x01(\x04\x12\x17\n\x0f\x63hannel_reserve\x18\x08 \x01(\x04\x12\x10\n\x08min_htlc\x18\t \x01(\x04\x12\x12\n\nfee_per_kw\x18\n \x01(\x04\x12\x11\n\tcsv_delay\x18\x0b \x01(\r\x12\x1a\n\x12max_accepted_htlcs\x18\x0c \x01(\r\x12\x15\n\rchannel_flags\x18\r \x01(\r\"@\n\x15\x43hannelAcceptResponse\x12\x0e\n\x06\x61\x63\x63\x65pt\x18\x01 \x01(\x08\x12\x17\n\x0fpending_chan_id\x18\x02 \x01(\x0c\"\xa2\x01\n\x0c\x43hannelPoint\x12\x30\n\x12\x66unding_txid_bytes\x18\x01 \x01(\x0cH\x00R\x12\x66unding_txid_bytes\x12,\n\x10\x66unding_txid_str\x18\x02 \x01(\tH\x00R\x10\x66unding_txid_str\x12\"\n\x0coutput_index\x18\x03 \x01(\rR\x0coutput_indexB\x0e\n\x0c\x66unding_txid\"j\n\x08OutPoint\x12\x1e\n\ntxid_bytes\x18\x01 \x01(\x0cR\ntxid_bytes\x12\x1a\n\x08txid_str\x18\x02 \x01(\tR\x08txid_str\x12\"\n\x0coutput_index\x18\x03 \x01(\rR\x0coutput_index\">\n\x10LightningAddress\x12\x16\n\x06pubkey\x18\x01 \x01(\tR\x06pubkey\x12\x12\n\x04host\x18\x02 \x01(\tR\x04host\"\xa1\x01\n\x12\x45stimateFeeRequest\x12\x41\n\x0c\x41\x64\x64rToAmount\x18\x01 \x03(\x0b\x32+.lnrpc.EstimateFeeRequest.AddrToAmountEntry\x12\x13\n\x0btarget_conf\x18\x02 \x01(\x05\x1a\x33\n\x11\x41\x64\x64rToAmountEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"c\n\x13\x45stimateFeeResponse\x12\x18\n\x07\x66\x65\x65_sat\x18\x01 \x01(\x03R\x07\x66\x65\x65_sat\x12\x32\n\x14\x66\x65\x65rate_sat_per_byte\x18\x02 \x01(\x03R\x14\x66\x65\x65rate_sat_per_byte\"\xb1\x01\n\x0fSendManyRequest\x12>\n\x0c\x41\x64\x64rToAmount\x18\x01 \x03(\x0b\x32(.lnrpc.SendManyRequest.AddrToAmountEntry\x12\x13\n\x0btarget_conf\x18\x03 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x05 \x01(\x03\x1a\x33\n\x11\x41\x64\x64rToAmountEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"&\n\x10SendManyResponse\x12\x12\n\x04txid\x18\x01 \x01(\tR\x04txid\"m\n\x10SendCoinsRequest\x12\x0c\n\x04\x61\x64\x64r\x18\x01 \x01(\t\x12\x0e\n\x06\x61mount\x18\x02 \x01(\x03\x12\x13\n\x0btarget_conf\x18\x03 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x05 \x01(\x03\x12\x10\n\x08send_all\x18\x06 \x01(\x08\"\'\n\x11SendCoinsResponse\x12\x12\n\x04txid\x18\x01 \x01(\tR\x04txid\":\n\x12ListUnspentRequest\x12\x11\n\tmin_confs\x18\x01 \x01(\x05\x12\x11\n\tmax_confs\x18\x02 \x01(\x05\"8\n\x13ListUnspentResponse\x12!\n\x05utxos\x18\x01 \x03(\x0b\x32\x0b.lnrpc.UtxoR\x05utxos\"5\n\x11NewAddressRequest\x12 \n\x04type\x18\x01 \x01(\x0e\x32\x12.lnrpc.AddressType\".\n\x12NewAddressResponse\x12\x18\n\x07\x61\x64\x64ress\x18\x01 \x01(\tR\x07\x61\x64\x64ress\"&\n\x12SignMessageRequest\x12\x10\n\x03msg\x18\x01 \x01(\x0cR\x03msg\"3\n\x13SignMessageResponse\x12\x1c\n\tsignature\x18\x01 \x01(\tR\tsignature\"F\n\x14VerifyMessageRequest\x12\x10\n\x03msg\x18\x01 \x01(\x0cR\x03msg\x12\x1c\n\tsignature\x18\x02 \x01(\tR\tsignature\"E\n\x15VerifyMessageResponse\x12\x14\n\x05valid\x18\x01 \x01(\x08R\x05valid\x12\x16\n\x06pubkey\x18\x02 \x01(\tR\x06pubkey\"I\n\x12\x43onnectPeerRequest\x12%\n\x04\x61\x64\x64r\x18\x01 \x01(\x0b\x32\x17.lnrpc.LightningAddress\x12\x0c\n\x04perm\x18\x02 \x01(\x08\"\x15\n\x13\x43onnectPeerResponse\"1\n\x15\x44isconnectPeerRequest\x12\x18\n\x07pub_key\x18\x01 \x01(\tR\x07pub_key\"\x18\n\x16\x44isconnectPeerResponse\"\x86\x01\n\x04HTLC\x12\x1a\n\x08incoming\x18\x01 \x01(\x08R\x08incoming\x12\x16\n\x06\x61mount\x18\x02 \x01(\x03R\x06\x61mount\x12\x1c\n\thash_lock\x18\x03 \x01(\x0cR\thash_lock\x12,\n\x11\x65xpiration_height\x18\x04 \x01(\rR\x11\x65xpiration_height\"\xa2\x07\n\x07\x43hannel\x12\x16\n\x06\x61\x63tive\x18\x01 \x01(\x08R\x06\x61\x63tive\x12$\n\rremote_pubkey\x18\x02 \x01(\tR\rremote_pubkey\x12$\n\rchannel_point\x18\x03 \x01(\tR\rchannel_point\x12\x1c\n\x07\x63han_id\x18\x04 \x01(\x04\x42\x02\x30\x01R\x07\x63han_id\x12\x1a\n\x08\x63\x61pacity\x18\x05 \x01(\x03R\x08\x63\x61pacity\x12$\n\rlocal_balance\x18\x06 \x01(\x03R\rlocal_balance\x12&\n\x0eremote_balance\x18\x07 \x01(\x03R\x0eremote_balance\x12\x1e\n\ncommit_fee\x18\x08 \x01(\x03R\ncommit_fee\x12$\n\rcommit_weight\x18\t \x01(\x03R\rcommit_weight\x12\x1e\n\nfee_per_kw\x18\n \x01(\x03R\nfee_per_kw\x12,\n\x11unsettled_balance\x18\x0b \x01(\x03R\x11unsettled_balance\x12\x30\n\x13total_satoshis_sent\x18\x0c \x01(\x03R\x13total_satoshis_sent\x12\x38\n\x17total_satoshis_received\x18\r \x01(\x03R\x17total_satoshis_received\x12 \n\x0bnum_updates\x18\x0e \x01(\x04R\x0bnum_updates\x12\x31\n\rpending_htlcs\x18\x0f \x03(\x0b\x32\x0b.lnrpc.HTLCR\rpending_htlcs\x12\x1c\n\tcsv_delay\x18\x10 \x01(\rR\tcsv_delay\x12\x18\n\x07private\x18\x11 \x01(\x08R\x07private\x12\x1c\n\tinitiator\x18\x12 \x01(\x08R\tinitiator\x12,\n\x11\x63han_status_flags\x18\x13 \x01(\tR\x11\x63han_status_flags\x12\x36\n\x16local_chan_reserve_sat\x18\x14 \x01(\x03R\x16local_chan_reserve_sat\x12\x38\n\x17remote_chan_reserve_sat\x18\x15 \x01(\x03R\x17remote_chan_reserve_sat\x12,\n\x11static_remote_key\x18\x16 \x01(\x08R\x11static_remote_key\x12\x1a\n\x08lifetime\x18\x17 \x01(\x03R\x08lifetime\x12\x16\n\x06uptime\x18\x18 \x01(\x03R\x06uptime\"l\n\x13ListChannelsRequest\x12\x13\n\x0b\x61\x63tive_only\x18\x01 \x01(\x08\x12\x15\n\rinactive_only\x18\x02 \x01(\x08\x12\x13\n\x0bpublic_only\x18\x03 \x01(\x08\x12\x14\n\x0cprivate_only\x18\x04 \x01(\x08\"B\n\x14ListChannelsResponse\x12*\n\x08\x63hannels\x18\x0b \x03(\x0b\x32\x0e.lnrpc.ChannelR\x08\x63hannels\"\xba\x04\n\x13\x43hannelCloseSummary\x12$\n\rchannel_point\x18\x01 \x01(\tR\rchannel_point\x12\x1c\n\x07\x63han_id\x18\x02 \x01(\x04\x42\x02\x30\x01R\x07\x63han_id\x12\x1e\n\nchain_hash\x18\x03 \x01(\tR\nchain_hash\x12(\n\x0f\x63losing_tx_hash\x18\x04 \x01(\tR\x0f\x63losing_tx_hash\x12$\n\rremote_pubkey\x18\x05 \x01(\tR\rremote_pubkey\x12\x1a\n\x08\x63\x61pacity\x18\x06 \x01(\x03R\x08\x63\x61pacity\x12\"\n\x0c\x63lose_height\x18\x07 \x01(\rR\x0c\x63lose_height\x12(\n\x0fsettled_balance\x18\x08 \x01(\x03R\x0fsettled_balance\x12\x30\n\x13time_locked_balance\x18\t \x01(\x03R\x13time_locked_balance\x12\x46\n\nclose_type\x18\n \x01(\x0e\x32&.lnrpc.ChannelCloseSummary.ClosureTypeR\nclose_type\"\x8a\x01\n\x0b\x43losureType\x12\x15\n\x11\x43OOPERATIVE_CLOSE\x10\x00\x12\x15\n\x11LOCAL_FORCE_CLOSE\x10\x01\x12\x16\n\x12REMOTE_FORCE_CLOSE\x10\x02\x12\x10\n\x0c\x42REACH_CLOSE\x10\x03\x12\x14\n\x10\x46UNDING_CANCELED\x10\x04\x12\r\n\tABANDONED\x10\x05\"\x94\x01\n\x15\x43losedChannelsRequest\x12\x13\n\x0b\x63ooperative\x18\x01 \x01(\x08\x12\x13\n\x0blocal_force\x18\x02 \x01(\x08\x12\x14\n\x0cremote_force\x18\x03 \x01(\x08\x12\x0e\n\x06\x62reach\x18\x04 \x01(\x08\x12\x18\n\x10\x66unding_canceled\x18\x05 \x01(\x08\x12\x11\n\tabandoned\x18\x06 \x01(\x08\"P\n\x16\x43losedChannelsResponse\x12\x36\n\x08\x63hannels\x18\x01 \x03(\x0b\x32\x1a.lnrpc.ChannelCloseSummaryR\x08\x63hannels\"\xdf\x02\n\x04Peer\x12\x18\n\x07pub_key\x18\x01 \x01(\tR\x07pub_key\x12\x18\n\x07\x61\x64\x64ress\x18\x03 \x01(\tR\x07\x61\x64\x64ress\x12\x1e\n\nbytes_sent\x18\x04 \x01(\x04R\nbytes_sent\x12\x1e\n\nbytes_recv\x18\x05 \x01(\x04R\nbytes_recv\x12\x1a\n\x08sat_sent\x18\x06 \x01(\x03R\x08sat_sent\x12\x1a\n\x08sat_recv\x18\x07 \x01(\x03R\x08sat_recv\x12\x18\n\x07inbound\x18\x08 \x01(\x08R\x07inbound\x12\x1c\n\tping_time\x18\t \x01(\x03R\tping_time\x12\x32\n\tsync_type\x18\n \x01(\x0e\x32\x14.lnrpc.Peer.SyncTypeR\tsync_type\"?\n\x08SyncType\x12\x10\n\x0cUNKNOWN_SYNC\x10\x00\x12\x0f\n\x0b\x41\x43TIVE_SYNC\x10\x01\x12\x10\n\x0cPASSIVE_SYNC\x10\x02\"\x12\n\x10ListPeersRequest\"6\n\x11ListPeersResponse\x12!\n\x05peers\x18\x01 \x03(\x0b\x32\x0b.lnrpc.PeerR\x05peers\"\x10\n\x0eGetInfoRequest\"\xe7\x04\n\x0fGetInfoResponse\x12(\n\x0fidentity_pubkey\x18\x01 \x01(\tR\x0fidentity_pubkey\x12\x14\n\x05\x61lias\x18\x02 \x01(\tR\x05\x61lias\x12\x32\n\x14num_pending_channels\x18\x03 \x01(\rR\x14num_pending_channels\x12\x30\n\x13num_active_channels\x18\x04 \x01(\rR\x13num_active_channels\x12\x1c\n\tnum_peers\x18\x05 \x01(\rR\tnum_peers\x12\"\n\x0c\x62lock_height\x18\x06 \x01(\rR\x0c\x62lock_height\x12\x1e\n\nblock_hash\x18\x08 \x01(\tR\nblock_hash\x12(\n\x0fsynced_to_chain\x18\t \x01(\x08R\x0fsynced_to_chain\x12\x1c\n\x07testnet\x18\n \x01(\x08\x42\x02\x18\x01R\x07testnet\x12\x12\n\x04uris\x18\x0c \x03(\tR\x04uris\x12\x34\n\x15\x62\x65st_header_timestamp\x18\r \x01(\x03R\x15\x62\x65st_header_timestamp\x12\x18\n\x07version\x18\x0e \x01(\tR\x07version\x12\x34\n\x15num_inactive_channels\x18\x0f \x01(\rR\x15num_inactive_channels\x12$\n\x06\x63hains\x18\x10 \x03(\x0b\x32\x0c.lnrpc.ChainR\x06\x63hains\x12\x14\n\x05\x63olor\x18\x11 \x01(\tR\x05\x63olor\x12(\n\x0fsynced_to_graph\x18\x12 \x01(\x08R\x0fsynced_to_graphJ\x04\x08\x0b\x10\x0c\"7\n\x05\x43hain\x12\x14\n\x05\x63hain\x18\x01 \x01(\tR\x05\x63hain\x12\x18\n\x07network\x18\x02 \x01(\tR\x07network\"U\n\x12\x43onfirmationUpdate\x12\x11\n\tblock_sha\x18\x01 \x01(\x0c\x12\x14\n\x0c\x62lock_height\x18\x02 \x01(\x05\x12\x16\n\x0enum_confs_left\x18\x03 \x01(\r\"N\n\x11\x43hannelOpenUpdate\x12\x39\n\rchannel_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPointR\rchannel_point\"R\n\x12\x43hannelCloseUpdate\x12\"\n\x0c\x63losing_txid\x18\x01 \x01(\x0cR\x0c\x63losing_txid\x12\x18\n\x07success\x18\x02 \x01(\x08R\x07success\"{\n\x13\x43loseChannelRequest\x12*\n\rchannel_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\x12\x13\n\x0btarget_conf\x18\x03 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x04 \x01(\x03\"\x98\x01\n\x11\x43loseStatusUpdate\x12<\n\rclose_pending\x18\x01 \x01(\x0b\x32\x14.lnrpc.PendingUpdateH\x00R\rclose_pending\x12;\n\nchan_close\x18\x03 \x01(\x0b\x32\x19.lnrpc.ChannelCloseUpdateH\x00R\nchan_closeB\x08\n\x06update\"G\n\rPendingUpdate\x12\x12\n\x04txid\x18\x01 \x01(\x0cR\x04txid\x12\"\n\x0coutput_index\x18\x02 \x01(\rR\x0coutput_index\"\x99\x03\n\x12OpenChannelRequest\x12 \n\x0bnode_pubkey\x18\x02 \x01(\x0cR\x0bnode_pubkey\x12.\n\x12node_pubkey_string\x18\x03 \x01(\tR\x12node_pubkey_string\x12\x32\n\x14local_funding_amount\x18\x04 \x01(\x03R\x14local_funding_amount\x12\x1a\n\x08push_sat\x18\x05 \x01(\x03R\x08push_sat\x12\x13\n\x0btarget_conf\x18\x06 \x01(\x05\x12\x14\n\x0csat_per_byte\x18\x07 \x01(\x03\x12\x18\n\x07private\x18\x08 \x01(\x08R\x07private\x12$\n\rmin_htlc_msat\x18\t \x01(\x03R\rmin_htlc_msat\x12*\n\x10remote_csv_delay\x18\n \x01(\rR\x10remote_csv_delay\x12\x1c\n\tmin_confs\x18\x0b \x01(\x05R\tmin_confs\x12,\n\x11spend_unconfirmed\x18\x0c \x01(\x08R\x11spend_unconfirmed\"\x92\x01\n\x10OpenStatusUpdate\x12:\n\x0c\x63han_pending\x18\x01 \x01(\x0b\x32\x14.lnrpc.PendingUpdateH\x00R\x0c\x63han_pending\x12\x38\n\tchan_open\x18\x03 \x01(\x0b\x32\x18.lnrpc.ChannelOpenUpdateH\x00R\tchan_openB\x08\n\x06update\"\xcf\x01\n\x0bPendingHTLC\x12\x1a\n\x08incoming\x18\x01 \x01(\x08R\x08incoming\x12\x16\n\x06\x61mount\x18\x02 \x01(\x03R\x06\x61mount\x12\x1a\n\x08outpoint\x18\x03 \x01(\tR\x08outpoint\x12(\n\x0fmaturity_height\x18\x04 \x01(\rR\x0fmaturity_height\x12\x30\n\x13\x62locks_til_maturity\x18\x05 \x01(\x05R\x13\x62locks_til_maturity\x12\x14\n\x05stage\x18\x06 \x01(\rR\x05stage\"\x18\n\x16PendingChannelsRequest\"\x9c\r\n\x17PendingChannelsResponse\x12\x30\n\x13total_limbo_balance\x18\x01 \x01(\x03R\x13total_limbo_balance\x12g\n\x15pending_open_channels\x18\x02 \x03(\x0b\x32\x31.lnrpc.PendingChannelsResponse.PendingOpenChannelR\x15pending_open_channels\x12h\n\x18pending_closing_channels\x18\x03 \x03(\x0b\x32,.lnrpc.PendingChannelsResponse.ClosedChannelR\x18pending_closing_channels\x12y\n\x1epending_force_closing_channels\x18\x04 \x03(\x0b\x32\x31.lnrpc.PendingChannelsResponse.ForceClosedChannelR\x1epending_force_closing_channels\x12j\n\x16waiting_close_channels\x18\x05 \x03(\x0b\x32\x32.lnrpc.PendingChannelsResponse.WaitingCloseChannelR\x16waiting_close_channels\x1a\xbc\x02\n\x0ePendingChannel\x12(\n\x0fremote_node_pub\x18\x01 \x01(\tR\x0fremote_node_pub\x12$\n\rchannel_point\x18\x02 \x01(\tR\rchannel_point\x12\x1a\n\x08\x63\x61pacity\x18\x03 \x01(\x03R\x08\x63\x61pacity\x12$\n\rlocal_balance\x18\x04 \x01(\x03R\rlocal_balance\x12&\n\x0eremote_balance\x18\x05 \x01(\x03R\x0eremote_balance\x12\x36\n\x16local_chan_reserve_sat\x18\x06 \x01(\x03R\x16local_chan_reserve_sat\x12\x38\n\x17remote_chan_reserve_sat\x18\x07 \x01(\x03R\x17remote_chan_reserve_sat\x1a\xf5\x01\n\x12PendingOpenChannel\x12G\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannelR\x07\x63hannel\x12\x30\n\x13\x63onfirmation_height\x18\x02 \x01(\rR\x13\x63onfirmation_height\x12\x1e\n\ncommit_fee\x18\x04 \x01(\x03R\ncommit_fee\x12$\n\rcommit_weight\x18\x05 \x01(\x03R\rcommit_weight\x12\x1e\n\nfee_per_kw\x18\x06 \x01(\x03R\nfee_per_kw\x1a{\n\x13WaitingCloseChannel\x12>\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannel\x12$\n\rlimbo_balance\x18\x02 \x01(\x03R\rlimbo_balance\x1as\n\rClosedChannel\x12>\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannel\x12\"\n\x0c\x63losing_txid\x18\x02 \x01(\tR\x0c\x63losing_txid\x1a\xeb\x02\n\x12\x46orceClosedChannel\x12G\n\x07\x63hannel\x18\x01 \x01(\x0b\x32-.lnrpc.PendingChannelsResponse.PendingChannelR\x07\x63hannel\x12\"\n\x0c\x63losing_txid\x18\x02 \x01(\tR\x0c\x63losing_txid\x12$\n\rlimbo_balance\x18\x03 \x01(\x03R\rlimbo_balance\x12(\n\x0fmaturity_height\x18\x04 \x01(\rR\x0fmaturity_height\x12\x30\n\x13\x62locks_til_maturity\x18\x05 \x01(\x05R\x13\x62locks_til_maturity\x12,\n\x11recovered_balance\x18\x06 \x01(\x03R\x11recovered_balance\x12\x38\n\rpending_htlcs\x18\x08 \x03(\x0b\x32\x12.lnrpc.PendingHTLCR\rpending_htlcs\"\x1a\n\x18\x43hannelEventSubscription\"\xb5\x03\n\x12\x43hannelEventUpdate\x12\x34\n\x0copen_channel\x18\x01 \x01(\x0b\x32\x0e.lnrpc.ChannelH\x00R\x0copen_channel\x12\x44\n\x0e\x63losed_channel\x18\x02 \x01(\x0b\x32\x1a.lnrpc.ChannelCloseSummaryH\x00R\x0e\x63losed_channel\x12=\n\x0e\x61\x63tive_channel\x18\x03 \x01(\x0b\x32\x13.lnrpc.ChannelPointH\x00R\x0e\x61\x63tive_channel\x12\x41\n\x10inactive_channel\x18\x04 \x01(\x0b\x32\x13.lnrpc.ChannelPointH\x00R\x10inactive_channel\x12\x38\n\x04type\x18\x05 \x01(\x0e\x32$.lnrpc.ChannelEventUpdate.UpdateTypeR\x04type\"\\\n\nUpdateType\x12\x10\n\x0cOPEN_CHANNEL\x10\x00\x12\x12\n\x0e\x43LOSED_CHANNEL\x10\x01\x12\x12\n\x0e\x41\x43TIVE_CHANNEL\x10\x02\x12\x14\n\x10INACTIVE_CHANNEL\x10\x03\x42\t\n\x07\x63hannel\"\x16\n\x14WalletBalanceRequest\"\x9d\x01\n\x15WalletBalanceResponse\x12$\n\rtotal_balance\x18\x01 \x01(\x03R\rtotal_balance\x12,\n\x11\x63onfirmed_balance\x18\x02 \x01(\x03R\x11\x63onfirmed_balance\x12\x30\n\x13unconfirmed_balance\x18\x03 \x01(\x03R\x13unconfirmed_balance\"\x17\n\x15\x43hannelBalanceRequest\"f\n\x16\x43hannelBalanceResponse\x12\x18\n\x07\x62\x61lance\x18\x01 \x01(\x03R\x07\x62\x61lance\x12\x32\n\x14pending_open_balance\x18\x02 \x01(\x03R\x14pending_open_balance\"\xad\x02\n\x12QueryRoutesRequest\x12\x0f\n\x07pub_key\x18\x01 \x01(\t\x12\x0b\n\x03\x61mt\x18\x02 \x01(\x03\x12\x18\n\x10\x66inal_cltv_delta\x18\x04 \x01(\x05\x12\"\n\tfee_limit\x18\x05 \x01(\x0b\x32\x0f.lnrpc.FeeLimit\x12\x15\n\rignored_nodes\x18\x06 \x03(\x0c\x12-\n\rignored_edges\x18\x07 \x03(\x0b\x32\x12.lnrpc.EdgeLocatorB\x02\x18\x01\x12\x16\n\x0esource_pub_key\x18\x08 \x01(\t\x12\x1b\n\x13use_mission_control\x18\t \x01(\x08\x12&\n\rignored_pairs\x18\n \x03(\x0b\x32\x0f.lnrpc.NodePair\x12\x12\n\ncltv_limit\x18\x0b \x01(\rJ\x04\x08\x03\x10\x04\"$\n\x08NodePair\x12\x0c\n\x04\x66rom\x18\x01 \x01(\x0c\x12\n\n\x02to\x18\x02 \x01(\x0c\"@\n\x0b\x45\x64geLocator\x12\x16\n\nchannel_id\x18\x01 \x01(\x04\x42\x02\x30\x01\x12\x19\n\x11\x64irection_reverse\x18\x02 \x01(\x08\"_\n\x13QueryRoutesResponse\x12$\n\x06routes\x18\x01 \x03(\x0b\x32\x0c.lnrpc.RouteR\x06routes\x12\"\n\x0csuccess_prob\x18\x02 \x01(\x01R\x0csuccess_prob\"\xdf\x02\n\x03Hop\x12\x1c\n\x07\x63han_id\x18\x01 \x01(\x04\x42\x02\x30\x01R\x07\x63han_id\x12$\n\rchan_capacity\x18\x02 \x01(\x03R\rchan_capacity\x12*\n\x0e\x61mt_to_forward\x18\x03 \x01(\x03\x42\x02\x18\x01R\x0e\x61mt_to_forward\x12\x14\n\x03\x66\x65\x65\x18\x04 \x01(\x03\x42\x02\x18\x01R\x03\x66\x65\x65\x12\x16\n\x06\x65xpiry\x18\x05 \x01(\rR\x06\x65xpiry\x12\x30\n\x13\x61mt_to_forward_msat\x18\x06 \x01(\x03R\x13\x61mt_to_forward_msat\x12\x1a\n\x08\x66\x65\x65_msat\x18\x07 \x01(\x03R\x08\x66\x65\x65_msat\x12\x18\n\x07pub_key\x18\x08 \x01(\tR\x07pub_key\x12 \n\x0btlv_payload\x18\t \x01(\x08R\x0btlv_payload\x12\x30\n\nmpp_record\x18\n \x01(\x0b\x32\x10.lnrpc.MPPRecordR\nmpp_record\"W\n\tMPPRecord\x12\"\n\x0cpayment_addr\x18\x0b \x01(\x0cR\x0cpayment_addr\x12&\n\x0etotal_amt_msat\x18\n \x01(\x03R\x0etotal_amt_msat\"\xe9\x01\n\x05Route\x12(\n\x0ftotal_time_lock\x18\x01 \x01(\rR\x0ftotal_time_lock\x12\"\n\ntotal_fees\x18\x02 \x01(\x03\x42\x02\x18\x01R\ntotal_fees\x12 \n\ttotal_amt\x18\x03 \x01(\x03\x42\x02\x18\x01R\ttotal_amt\x12\x1e\n\x04hops\x18\x04 \x03(\x0b\x32\n.lnrpc.HopR\x04hops\x12(\n\x0ftotal_fees_msat\x18\x05 \x01(\x03R\x0ftotal_fees_msat\x12&\n\x0etotal_amt_msat\x18\x06 \x01(\x03R\x0etotal_amt_msat\"<\n\x0fNodeInfoRequest\x12\x0f\n\x07pub_key\x18\x01 \x01(\t\x12\x18\n\x10include_channels\x18\x02 \x01(\x08\"\xb0\x01\n\x08NodeInfo\x12(\n\x04node\x18\x01 \x01(\x0b\x32\x14.lnrpc.LightningNodeR\x04node\x12\"\n\x0cnum_channels\x18\x02 \x01(\rR\x0cnum_channels\x12&\n\x0etotal_capacity\x18\x03 \x01(\x03R\x0etotal_capacity\x12.\n\x08\x63hannels\x18\x04 \x03(\x0b\x32\x12.lnrpc.ChannelEdgeR\x08\x63hannels\"\xa9\x01\n\rLightningNode\x12 \n\x0blast_update\x18\x01 \x01(\rR\x0blast_update\x12\x18\n\x07pub_key\x18\x02 \x01(\tR\x07pub_key\x12\x14\n\x05\x61lias\x18\x03 \x01(\tR\x05\x61lias\x12\x30\n\taddresses\x18\x04 \x03(\x0b\x32\x12.lnrpc.NodeAddressR\taddresses\x12\x14\n\x05\x63olor\x18\x05 \x01(\tR\x05\x63olor\";\n\x0bNodeAddress\x12\x18\n\x07network\x18\x01 \x01(\tR\x07network\x12\x12\n\x04\x61\x64\x64r\x18\x02 \x01(\tR\x04\x61\x64\x64r\"\x91\x02\n\rRoutingPolicy\x12(\n\x0ftime_lock_delta\x18\x01 \x01(\rR\x0ftime_lock_delta\x12\x1a\n\x08min_htlc\x18\x02 \x01(\x03R\x08min_htlc\x12$\n\rfee_base_msat\x18\x03 \x01(\x03R\rfee_base_msat\x12\x30\n\x13\x66\x65\x65_rate_milli_msat\x18\x04 \x01(\x03R\x13\x66\x65\x65_rate_milli_msat\x12\x1a\n\x08\x64isabled\x18\x05 \x01(\x08R\x08\x64isabled\x12$\n\rmax_htlc_msat\x18\x06 \x01(\x04R\rmax_htlc_msat\x12 \n\x0blast_update\x18\x07 \x01(\rR\x0blast_update\"\xc3\x02\n\x0b\x43hannelEdge\x12\"\n\nchannel_id\x18\x01 \x01(\x04\x42\x02\x30\x01R\nchannel_id\x12\x1e\n\nchan_point\x18\x02 \x01(\tR\nchan_point\x12$\n\x0blast_update\x18\x03 \x01(\rB\x02\x18\x01R\x0blast_update\x12\x1c\n\tnode1_pub\x18\x04 \x01(\tR\tnode1_pub\x12\x1c\n\tnode2_pub\x18\x05 \x01(\tR\tnode2_pub\x12\x1a\n\x08\x63\x61pacity\x18\x06 \x01(\x03R\x08\x63\x61pacity\x12\x38\n\x0cnode1_policy\x18\x07 \x01(\x0b\x32\x14.lnrpc.RoutingPolicyR\x0cnode1_policy\x12\x38\n\x0cnode2_policy\x18\x08 \x01(\x0b\x32\x14.lnrpc.RoutingPolicyR\x0cnode2_policy\"G\n\x13\x43hannelGraphRequest\x12\x30\n\x13include_unannounced\x18\x01 \x01(\x08R\x13include_unannounced\"d\n\x0c\x43hannelGraph\x12*\n\x05nodes\x18\x01 \x03(\x0b\x32\x14.lnrpc.LightningNodeR\x05nodes\x12(\n\x05\x65\x64ges\x18\x02 \x03(\x0b\x32\x12.lnrpc.ChannelEdgeR\x05\x65\x64ges\"&\n\x0f\x43hanInfoRequest\x12\x13\n\x07\x63han_id\x18\x01 \x01(\x04\x42\x02\x30\x01\"\x14\n\x12NetworkInfoRequest\"\xe9\x03\n\x0bNetworkInfo\x12&\n\x0egraph_diameter\x18\x01 \x01(\rR\x0egraph_diameter\x12&\n\x0e\x61vg_out_degree\x18\x02 \x01(\x01R\x0e\x61vg_out_degree\x12&\n\x0emax_out_degree\x18\x03 \x01(\rR\x0emax_out_degree\x12\x1c\n\tnum_nodes\x18\x04 \x01(\rR\tnum_nodes\x12\"\n\x0cnum_channels\x18\x05 \x01(\rR\x0cnum_channels\x12\x36\n\x16total_network_capacity\x18\x06 \x01(\x03R\x16total_network_capacity\x12*\n\x10\x61vg_channel_size\x18\x07 \x01(\x01R\x10\x61vg_channel_size\x12*\n\x10min_channel_size\x18\x08 \x01(\x03R\x10min_channel_size\x12*\n\x10max_channel_size\x18\t \x01(\x03R\x10max_channel_size\x12\x38\n\x17median_channel_size_sat\x18\n \x01(\x03R\x17median_channel_size_sat\x12*\n\x10num_zombie_chans\x18\x0b \x01(\x04R\x10num_zombie_chans\"\r\n\x0bStopRequest\"\x0e\n\x0cStopResponse\"\x1b\n\x19GraphTopologySubscription\"\xa3\x01\n\x13GraphTopologyUpdate\x12\'\n\x0cnode_updates\x18\x01 \x03(\x0b\x32\x11.lnrpc.NodeUpdate\x12\x31\n\x0f\x63hannel_updates\x18\x02 \x03(\x0b\x32\x18.lnrpc.ChannelEdgeUpdate\x12\x30\n\x0c\x63losed_chans\x18\x03 \x03(\x0b\x32\x1a.lnrpc.ClosedChannelUpdate\"l\n\nNodeUpdate\x12\x11\n\taddresses\x18\x01 \x03(\t\x12\x14\n\x0cidentity_key\x18\x02 \x01(\t\x12\x17\n\x0fglobal_features\x18\x03 \x01(\x0c\x12\r\n\x05\x61lias\x18\x04 \x01(\t\x12\r\n\x05\x63olor\x18\x05 \x01(\t\"\xc4\x01\n\x11\x43hannelEdgeUpdate\x12\x13\n\x07\x63han_id\x18\x01 \x01(\x04\x42\x02\x30\x01\x12\'\n\nchan_point\x18\x02 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\x12\x10\n\x08\x63\x61pacity\x18\x03 \x01(\x03\x12,\n\x0erouting_policy\x18\x04 \x01(\x0b\x32\x14.lnrpc.RoutingPolicy\x12\x18\n\x10\x61\x64vertising_node\x18\x05 \x01(\t\x12\x17\n\x0f\x63onnecting_node\x18\x06 \x01(\t\"|\n\x13\x43losedChannelUpdate\x12\x13\n\x07\x63han_id\x18\x01 \x01(\x04\x42\x02\x30\x01\x12\x10\n\x08\x63\x61pacity\x18\x02 \x01(\x03\x12\x15\n\rclosed_height\x18\x03 \x01(\r\x12\'\n\nchan_point\x18\x04 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\"\xd7\x01\n\x07HopHint\x12\x18\n\x07node_id\x18\x01 \x01(\tR\x07node_id\x12\x1c\n\x07\x63han_id\x18\x02 \x01(\x04\x42\x02\x30\x01R\x07\x63han_id\x12$\n\rfee_base_msat\x18\x03 \x01(\rR\rfee_base_msat\x12@\n\x1b\x66\x65\x65_proportional_millionths\x18\x04 \x01(\rR\x1b\x66\x65\x65_proportional_millionths\x12,\n\x11\x63ltv_expiry_delta\x18\x05 \x01(\rR\x11\x63ltv_expiry_delta\"9\n\tRouteHint\x12,\n\thop_hints\x18\x01 \x03(\x0b\x32\x0e.lnrpc.HopHintR\thop_hints\"\xbf\x06\n\x07Invoice\x12\x12\n\x04memo\x18\x01 \x01(\tR\x04memo\x12\x1c\n\x07receipt\x18\x02 \x01(\x0c\x42\x02\x18\x01R\x07receipt\x12\x1e\n\nr_preimage\x18\x03 \x01(\x0cR\nr_preimage\x12\x16\n\x06r_hash\x18\x04 \x01(\x0cR\x06r_hash\x12\x14\n\x05value\x18\x05 \x01(\x03R\x05value\x12\x1c\n\x07settled\x18\x06 \x01(\x08\x42\x02\x18\x01R\x07settled\x12$\n\rcreation_date\x18\x07 \x01(\x03R\rcreation_date\x12 \n\x0bsettle_date\x18\x08 \x01(\x03R\x0bsettle_date\x12(\n\x0fpayment_request\x18\t \x01(\tR\x0fpayment_request\x12*\n\x10\x64\x65scription_hash\x18\n \x01(\x0cR\x10\x64\x65scription_hash\x12\x16\n\x06\x65xpiry\x18\x0b \x01(\x03R\x06\x65xpiry\x12$\n\rfallback_addr\x18\x0c \x01(\tR\rfallback_addr\x12 \n\x0b\x63ltv_expiry\x18\r \x01(\x04R\x0b\x63ltv_expiry\x12\x32\n\x0broute_hints\x18\x0e \x03(\x0b\x32\x10.lnrpc.RouteHintR\x0broute_hints\x12\x18\n\x07private\x18\x0f \x01(\x08R\x07private\x12\x1c\n\tadd_index\x18\x10 \x01(\x04R\tadd_index\x12\"\n\x0csettle_index\x18\x11 \x01(\x04R\x0csettle_index\x12\x1e\n\x08\x61mt_paid\x18\x12 \x01(\x03\x42\x02\x18\x01R\x08\x61mt_paid\x12\"\n\x0c\x61mt_paid_sat\x18\x13 \x01(\x03R\x0c\x61mt_paid_sat\x12$\n\ramt_paid_msat\x18\x14 \x01(\x03R\ramt_paid_msat\x12\x31\n\x05state\x18\x15 \x01(\x0e\x32\x1b.lnrpc.Invoice.InvoiceStateR\x05state\x12(\n\x05htlcs\x18\x16 \x03(\x0b\x32\x12.lnrpc.InvoiceHTLCR\x05htlcs\"A\n\x0cInvoiceState\x12\x08\n\x04OPEN\x10\x00\x12\x0b\n\x07SETTLED\x10\x01\x12\x0c\n\x08\x43\x41NCELED\x10\x02\x12\x0c\n\x08\x41\x43\x43\x45PTED\x10\x03\"\xa8\x02\n\x0bInvoiceHTLC\x12\x1c\n\x07\x63han_id\x18\x01 \x01(\x04\x42\x02\x30\x01R\x07\x63han_id\x12\x1e\n\nhtlc_index\x18\x02 \x01(\x04R\nhtlc_index\x12\x1a\n\x08\x61mt_msat\x18\x03 \x01(\x04R\x08\x61mt_msat\x12$\n\raccept_height\x18\x04 \x01(\x05R\raccept_height\x12 \n\x0b\x61\x63\x63\x65pt_time\x18\x05 \x01(\x03R\x0b\x61\x63\x63\x65pt_time\x12\"\n\x0cresolve_time\x18\x06 \x01(\x03R\x0cresolve_time\x12$\n\rexpiry_height\x18\x07 \x01(\x05R\rexpiry_height\x12-\n\x05state\x18\x08 \x01(\x0e\x32\x17.lnrpc.InvoiceHTLCStateR\x05state\"t\n\x12\x41\x64\x64InvoiceResponse\x12\x16\n\x06r_hash\x18\x01 \x01(\x0cR\x06r_hash\x12(\n\x0fpayment_request\x18\x02 \x01(\tR\x0fpayment_request\x12\x1c\n\tadd_index\x18\x10 \x01(\x04R\tadd_index\"E\n\x0bPaymentHash\x12\x1e\n\nr_hash_str\x18\x01 \x01(\tR\nr_hash_str\x12\x16\n\x06r_hash\x18\x02 \x01(\x0cR\x06r_hash\"\xa4\x01\n\x12ListInvoiceRequest\x12\"\n\x0cpending_only\x18\x01 \x01(\x08R\x0cpending_only\x12\"\n\x0cindex_offset\x18\x04 \x01(\x04R\x0cindex_offset\x12*\n\x10num_max_invoices\x18\x05 \x01(\x04R\x10num_max_invoices\x12\x1a\n\x08reversed\x18\x06 \x01(\x08R\x08reversed\"\x9f\x01\n\x13ListInvoiceResponse\x12*\n\x08invoices\x18\x01 \x03(\x0b\x32\x0e.lnrpc.InvoiceR\x08invoices\x12,\n\x11last_index_offset\x18\x02 \x01(\x04R\x11last_index_offset\x12.\n\x12\x66irst_index_offset\x18\x03 \x01(\x04R\x12\x66irst_index_offset\"W\n\x13InvoiceSubscription\x12\x1c\n\tadd_index\x18\x01 \x01(\x04R\tadd_index\x12\"\n\x0csettle_index\x18\x02 \x01(\x04R\x0csettle_index\"\xdf\x03\n\x07Payment\x12\"\n\x0cpayment_hash\x18\x01 \x01(\tR\x0cpayment_hash\x12\x18\n\x05value\x18\x02 \x01(\x03\x42\x02\x18\x01R\x05value\x12$\n\rcreation_date\x18\x03 \x01(\x03R\rcreation_date\x12\x12\n\x04path\x18\x04 \x03(\tR\x04path\x12\x14\n\x03\x66\x65\x65\x18\x05 \x01(\x03\x42\x02\x18\x01R\x03\x66\x65\x65\x12*\n\x10payment_preimage\x18\x06 \x01(\tR\x10payment_preimage\x12\x1c\n\tvalue_sat\x18\x07 \x01(\x03R\tvalue_sat\x12\x1e\n\nvalue_msat\x18\x08 \x01(\x03R\nvalue_msat\x12(\n\x0fpayment_request\x18\t \x01(\tR\x0fpayment_request\x12\x34\n\x06status\x18\n \x01(\x0e\x32\x1c.lnrpc.Payment.PaymentStatusR\x06status\x12\x18\n\x07\x66\x65\x65_sat\x18\x0b \x01(\x03R\x07\x66\x65\x65_sat\x12\x1a\n\x08\x66\x65\x65_msat\x18\x0c \x01(\x03R\x08\x66\x65\x65_msat\"F\n\rPaymentStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\r\n\tIN_FLIGHT\x10\x01\x12\r\n\tSUCCEEDED\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\"1\n\x13ListPaymentsRequest\x12\x1a\n\x12include_incomplete\x18\x01 \x01(\x08\"B\n\x14ListPaymentsResponse\x12*\n\x08payments\x18\x01 \x03(\x0b\x32\x0e.lnrpc.PaymentR\x08payments\"\x1a\n\x18\x44\x65leteAllPaymentsRequest\"\x1b\n\x19\x44\x65leteAllPaymentsResponse\"C\n\x15\x41\x62\x61ndonChannelRequest\x12*\n\rchannel_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\"\x18\n\x16\x41\x62\x61ndonChannelResponse\"5\n\x11\x44\x65\x62ugLevelRequest\x12\x0c\n\x04show\x18\x01 \x01(\x08\x12\x12\n\nlevel_spec\x18\x02 \x01(\t\"6\n\x12\x44\x65\x62ugLevelResponse\x12 \n\x0bsub_systems\x18\x01 \x01(\tR\x0bsub_systems\"\x1f\n\x0cPayReqString\x12\x0f\n\x07pay_req\x18\x01 \x01(\t\"\xf2\x02\n\x06PayReq\x12 \n\x0b\x64\x65stination\x18\x01 \x01(\tR\x0b\x64\x65stination\x12\"\n\x0cpayment_hash\x18\x02 \x01(\tR\x0cpayment_hash\x12\"\n\x0cnum_satoshis\x18\x03 \x01(\x03R\x0cnum_satoshis\x12\x1c\n\ttimestamp\x18\x04 \x01(\x03R\ttimestamp\x12\x16\n\x06\x65xpiry\x18\x05 \x01(\x03R\x06\x65xpiry\x12 \n\x0b\x64\x65scription\x18\x06 \x01(\tR\x0b\x64\x65scription\x12*\n\x10\x64\x65scription_hash\x18\x07 \x01(\tR\x10\x64\x65scription_hash\x12$\n\rfallback_addr\x18\x08 \x01(\tR\rfallback_addr\x12 \n\x0b\x63ltv_expiry\x18\t \x01(\x03R\x0b\x63ltv_expiry\x12\x32\n\x0broute_hints\x18\n \x03(\x0b\x32\x10.lnrpc.RouteHintR\x0broute_hints\"\x12\n\x10\x46\x65\x65ReportRequest\"\x99\x01\n\x10\x43hannelFeeReport\x12!\n\nchan_point\x18\x01 \x01(\tR\rchannel_point\x12$\n\rbase_fee_msat\x18\x02 \x01(\x03R\rbase_fee_msat\x12 \n\x0b\x66\x65\x65_per_mil\x18\x03 \x01(\x03R\x0b\x66\x65\x65_per_mil\x12\x1a\n\x08\x66\x65\x65_rate\x18\x04 \x01(\x01R\x08\x66\x65\x65_rate\"\xbc\x01\n\x11\x46\x65\x65ReportResponse\x12;\n\x0c\x63hannel_fees\x18\x01 \x03(\x0b\x32\x17.lnrpc.ChannelFeeReportR\x0c\x63hannel_fees\x12 \n\x0b\x64\x61y_fee_sum\x18\x02 \x01(\x04R\x0b\x64\x61y_fee_sum\x12\"\n\x0cweek_fee_sum\x18\x03 \x01(\x04R\x0cweek_fee_sum\x12$\n\rmonth_fee_sum\x18\x04 \x01(\x04R\rmonth_fee_sum\"\x81\x02\n\x13PolicyUpdateRequest\x12\x18\n\x06global\x18\x01 \x01(\x08H\x00R\x06global\x12\x35\n\nchan_point\x18\x02 \x01(\x0b\x32\x13.lnrpc.ChannelPointH\x00R\nchan_point\x12$\n\rbase_fee_msat\x18\x03 \x01(\x03R\rbase_fee_msat\x12\x1a\n\x08\x66\x65\x65_rate\x18\x04 \x01(\x01R\x08\x66\x65\x65_rate\x12(\n\x0ftime_lock_delta\x18\x05 \x01(\rR\x0ftime_lock_delta\x12$\n\rmax_htlc_msat\x18\x06 \x01(\x04R\rmax_htlc_msatB\x07\n\x05scope\"\x16\n\x14PolicyUpdateResponse\"\xa2\x01\n\x18\x46orwardingHistoryRequest\x12\x1e\n\nstart_time\x18\x01 \x01(\x04R\nstart_time\x12\x1a\n\x08\x65nd_time\x18\x02 \x01(\x04R\x08\x65nd_time\x12\"\n\x0cindex_offset\x18\x03 \x01(\rR\x0cindex_offset\x12&\n\x0enum_max_events\x18\x04 \x01(\rR\x0enum_max_events\"\x9f\x02\n\x0f\x46orwardingEvent\x12\x1c\n\ttimestamp\x18\x01 \x01(\x04R\ttimestamp\x12\"\n\nchan_id_in\x18\x02 \x01(\x04\x42\x02\x30\x01R\nchan_id_in\x12$\n\x0b\x63han_id_out\x18\x04 \x01(\x04\x42\x02\x30\x01R\x0b\x63han_id_out\x12\x16\n\x06\x61mt_in\x18\x05 \x01(\x04R\x06\x61mt_in\x12\x18\n\x07\x61mt_out\x18\x06 \x01(\x04R\x07\x61mt_out\x12\x10\n\x03\x66\x65\x65\x18\x07 \x01(\x04R\x03\x66\x65\x65\x12\x1a\n\x08\x66\x65\x65_msat\x18\x08 \x01(\x04R\x08\x66\x65\x65_msat\x12 \n\x0b\x61mt_in_msat\x18\t \x01(\x04R\x0b\x61mt_in_msat\x12\"\n\x0c\x61mt_out_msat\x18\n \x01(\x04R\x0c\x61mt_out_msat\"\x8f\x01\n\x19\x46orwardingHistoryResponse\x12\x44\n\x11\x66orwarding_events\x18\x01 \x03(\x0b\x32\x16.lnrpc.ForwardingEventR\x11\x66orwarding_events\x12,\n\x11last_offset_index\x18\x02 \x01(\rR\x11last_offset_index\"E\n\x1a\x45xportChannelBackupRequest\x12\'\n\nchan_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPoint\"f\n\rChannelBackup\x12\x33\n\nchan_point\x18\x01 \x01(\x0b\x32\x13.lnrpc.ChannelPointR\nchan_point\x12 \n\x0b\x63han_backup\x18\x02 \x01(\x0cR\x0b\x63han_backup\"v\n\x0fMultiChanBackup\x12\x35\n\x0b\x63han_points\x18\x01 \x03(\x0b\x32\x13.lnrpc.ChannelPointR\x0b\x63han_points\x12,\n\x11multi_chan_backup\x18\x02 \x01(\x0cR\x11multi_chan_backup\"\x19\n\x17\x43hanBackupExportRequest\"\xa3\x01\n\x12\x43hanBackupSnapshot\x12G\n\x13single_chan_backups\x18\x01 \x01(\x0b\x32\x15.lnrpc.ChannelBackupsR\x13single_chan_backups\x12\x44\n\x11multi_chan_backup\x18\x02 \x01(\x0b\x32\x16.lnrpc.MultiChanBackupR\x11multi_chan_backup\"J\n\x0e\x43hannelBackups\x12\x38\n\x0c\x63han_backups\x18\x01 \x03(\x0b\x32\x14.lnrpc.ChannelBackupR\x0c\x63han_backups\"\x91\x01\n\x18RestoreChanBackupRequest\x12;\n\x0c\x63han_backups\x18\x01 \x01(\x0b\x32\x15.lnrpc.ChannelBackupsH\x00R\x0c\x63han_backups\x12.\n\x11multi_chan_backup\x18\x02 \x01(\x0cH\x00R\x11multi_chan_backupB\x08\n\x06\x62\x61\x63kup\"\x17\n\x15RestoreBackupResponse\"\x1b\n\x19\x43hannelBackupSubscription\"\x1a\n\x18VerifyChanBackupResponse\"D\n\x12MacaroonPermission\x12\x16\n\x06\x65ntity\x18\x01 \x01(\tR\x06\x65ntity\x12\x16\n\x06\x61\x63tion\x18\x02 \x01(\tR\x06\x61\x63tion\"R\n\x13\x42\x61keMacaroonRequest\x12;\n\x0bpermissions\x18\x01 \x03(\x0b\x32\x19.lnrpc.MacaroonPermissionR\x0bpermissions\"2\n\x14\x42\x61keMacaroonResponse\x12\x1a\n\x08macaroon\x18\x01 \x01(\tR\x08macaroon*}\n\x0b\x41\x64\x64ressType\x12\x17\n\x13WITNESS_PUBKEY_HASH\x10\x00\x12\x16\n\x12NESTED_PUBKEY_HASH\x10\x01\x12\x1e\n\x1aUNUSED_WITNESS_PUBKEY_HASH\x10\x02\x12\x1d\n\x19UNUSED_NESTED_PUBKEY_HASH\x10\x03*;\n\x10InvoiceHTLCState\x12\x0c\n\x08\x41\x43\x43\x45PTED\x10\x00\x12\x0b\n\x07SETTLED\x10\x01\x12\x0c\n\x08\x43\x41NCELED\x10\x02\x32\x91\x03\n\x0eWalletUnlocker\x12M\n\x07GenSeed\x12\x15.lnrpc.GenSeedRequest\x1a\x16.lnrpc.GenSeedResponse\"\x13\x82\xd3\xe4\x93\x02\r\x12\x0b/v1/genseed\x12\\\n\nInitWallet\x12\x18.lnrpc.InitWalletRequest\x1a\x19.lnrpc.InitWalletResponse\"\x19\x82\xd3\xe4\x93\x02\x13\"\x0e/v1/initwallet:\x01*\x12\x64\n\x0cUnlockWallet\x12\x1a.lnrpc.UnlockWalletRequest\x1a\x1b.lnrpc.UnlockWalletResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v1/unlockwallet:\x01*\x12l\n\x0e\x43hangePassword\x12\x1c.lnrpc.ChangePasswordRequest\x1a\x1d.lnrpc.ChangePasswordResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\"\x12/v1/changepassword:\x01*2\xca\'\n\tLightning\x12j\n\rWalletBalance\x12\x1b.lnrpc.WalletBalanceRequest\x1a\x1c.lnrpc.WalletBalanceResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/v1/balance/blockchain\x12k\n\x0e\x43hannelBalance\x12\x1c.lnrpc.ChannelBalanceRequest\x1a\x1d.lnrpc.ChannelBalanceResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/balance/channels\x12\x65\n\x0fGetTransactions\x12\x1d.lnrpc.GetTransactionsRequest\x1a\x19.lnrpc.TransactionDetails\"\x18\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/transactions\x12\x62\n\x0b\x45stimateFee\x12\x19.lnrpc.EstimateFeeRequest\x1a\x1a.lnrpc.EstimateFeeResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/transactions/fee\x12[\n\tSendCoins\x12\x17.lnrpc.SendCoinsRequest\x1a\x18.lnrpc.SendCoinsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v1/transactions:\x01*\x12W\n\x0bListUnspent\x12\x19.lnrpc.ListUnspentRequest\x1a\x1a.lnrpc.ListUnspentResponse\"\x11\x82\xd3\xe4\x93\x02\x0b\x12\t/v1/utxos\x12L\n\x15SubscribeTransactions\x12\x1d.lnrpc.GetTransactionsRequest\x1a\x12.lnrpc.Transaction0\x01\x12;\n\x08SendMany\x12\x16.lnrpc.SendManyRequest\x1a\x17.lnrpc.SendManyResponse\x12Y\n\nNewAddress\x12\x18.lnrpc.NewAddressRequest\x1a\x19.lnrpc.NewAddressResponse\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/newaddress\x12`\n\x0bSignMessage\x12\x19.lnrpc.SignMessageRequest\x1a\x1a.lnrpc.SignMessageResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\"\x0f/v1/signmessage:\x01*\x12h\n\rVerifyMessage\x12\x1b.lnrpc.VerifyMessageRequest\x1a\x1c.lnrpc.VerifyMessageResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/verifymessage:\x01*\x12Z\n\x0b\x43onnectPeer\x12\x19.lnrpc.ConnectPeerRequest\x1a\x1a.lnrpc.ConnectPeerResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\"\t/v1/peers:\x01*\x12j\n\x0e\x44isconnectPeer\x12\x1c.lnrpc.DisconnectPeerRequest\x1a\x1d.lnrpc.DisconnectPeerResponse\"\x1b\x82\xd3\xe4\x93\x02\x15*\x13/v1/peers/{pub_key}\x12Q\n\tListPeers\x12\x17.lnrpc.ListPeersRequest\x1a\x18.lnrpc.ListPeersResponse\"\x11\x82\xd3\xe4\x93\x02\x0b\x12\t/v1/peers\x12M\n\x07GetInfo\x12\x15.lnrpc.GetInfoRequest\x1a\x16.lnrpc.GetInfoResponse\"\x13\x82\xd3\xe4\x93\x02\r\x12\x0b/v1/getinfo\x12n\n\x0fPendingChannels\x12\x1d.lnrpc.PendingChannelsRequest\x1a\x1e.lnrpc.PendingChannelsResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/channels/pending\x12]\n\x0cListChannels\x12\x1a.lnrpc.ListChannelsRequest\x1a\x1b.lnrpc.ListChannelsResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/v1/channels\x12V\n\x16SubscribeChannelEvents\x12\x1f.lnrpc.ChannelEventSubscription\x1a\x19.lnrpc.ChannelEventUpdate0\x01\x12j\n\x0e\x43losedChannels\x12\x1c.lnrpc.ClosedChannelsRequest\x1a\x1d.lnrpc.ClosedChannelsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/channels/closed\x12Z\n\x0fOpenChannelSync\x12\x19.lnrpc.OpenChannelRequest\x1a\x13.lnrpc.ChannelPoint\"\x17\x82\xd3\xe4\x93\x02\x11\"\x0c/v1/channels:\x01*\x12\x43\n\x0bOpenChannel\x12\x19.lnrpc.OpenChannelRequest\x1a\x17.lnrpc.OpenStatusUpdate0\x01\x12P\n\x0f\x43hannelAcceptor\x12\x1c.lnrpc.ChannelAcceptResponse\x1a\x1b.lnrpc.ChannelAcceptRequest(\x01\x30\x01\x12\x9a\x01\n\x0c\x43loseChannel\x12\x1a.lnrpc.CloseChannelRequest\x1a\x18.lnrpc.CloseStatusUpdate\"R\x82\xd3\xe4\x93\x02L*J/v1/channels/{channel_point.funding_txid_str}/{channel_point.output_index}0\x01\x12\xa9\x01\n\x0e\x41\x62\x61ndonChannel\x12\x1c.lnrpc.AbandonChannelRequest\x1a\x1d.lnrpc.AbandonChannelResponse\"Z\x82\xd3\xe4\x93\x02T*R/v1/channels/abandon/{channel_point.funding_txid_str}/{channel_point.output_index}\x12:\n\x0bSendPayment\x12\x12.lnrpc.SendRequest\x1a\x13.lnrpc.SendResponse(\x01\x30\x01\x12`\n\x0fSendPaymentSync\x12\x12.lnrpc.SendRequest\x1a\x13.lnrpc.SendResponse\"$\x82\xd3\xe4\x93\x02\x1e\"\x19/v1/channels/transactions:\x01*\x12\x41\n\x0bSendToRoute\x12\x19.lnrpc.SendToRouteRequest\x1a\x13.lnrpc.SendResponse(\x01\x30\x01\x12m\n\x0fSendToRouteSync\x12\x19.lnrpc.SendToRouteRequest\x1a\x13.lnrpc.SendResponse\"*\x82\xd3\xe4\x93\x02$\"\x1f/v1/channels/transactions/route:\x01*\x12P\n\nAddInvoice\x12\x0e.lnrpc.Invoice\x1a\x19.lnrpc.AddInvoiceResponse\"\x17\x82\xd3\xe4\x93\x02\x11\"\x0c/v1/invoices:\x01*\x12[\n\x0cListInvoices\x12\x19.lnrpc.ListInvoiceRequest\x1a\x1a.lnrpc.ListInvoiceResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/v1/invoices\x12U\n\rLookupInvoice\x12\x12.lnrpc.PaymentHash\x1a\x0e.lnrpc.Invoice\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/invoice/{r_hash_str}\x12\x61\n\x11SubscribeInvoices\x12\x1a.lnrpc.InvoiceSubscription\x1a\x0e.lnrpc.Invoice\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/v1/invoices/subscribe0\x01\x12P\n\x0c\x44\x65\x63odePayReq\x12\x13.lnrpc.PayReqString\x1a\r.lnrpc.PayReq\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/payreq/{pay_req}\x12]\n\x0cListPayments\x12\x1a.lnrpc.ListPaymentsRequest\x1a\x1b.lnrpc.ListPaymentsResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/v1/payments\x12l\n\x11\x44\x65leteAllPayments\x12\x1f.lnrpc.DeleteAllPaymentsRequest\x1a .lnrpc.DeleteAllPaymentsResponse\"\x14\x82\xd3\xe4\x93\x02\x0e*\x0c/v1/payments\x12S\n\rDescribeGraph\x12\x1a.lnrpc.ChannelGraphRequest\x1a\x13.lnrpc.ChannelGraph\"\x11\x82\xd3\xe4\x93\x02\x0b\x12\t/v1/graph\x12[\n\x0bGetChanInfo\x12\x16.lnrpc.ChanInfoRequest\x1a\x12.lnrpc.ChannelEdge\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/graph/edge/{chan_id}\x12X\n\x0bGetNodeInfo\x12\x16.lnrpc.NodeInfoRequest\x1a\x0f.lnrpc.NodeInfo\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/graph/node/{pub_key}\x12n\n\x0bQueryRoutes\x12\x19.lnrpc.QueryRoutesRequest\x1a\x1a.lnrpc.QueryRoutesResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v1/graph/routes/{pub_key}/{amt}\x12W\n\x0eGetNetworkInfo\x12\x19.lnrpc.NetworkInfoRequest\x1a\x12.lnrpc.NetworkInfo\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/graph/info\x12\x35\n\nStopDaemon\x12\x12.lnrpc.StopRequest\x1a\x13.lnrpc.StopResponse\x12W\n\x15SubscribeChannelGraph\x12 .lnrpc.GraphTopologySubscription\x1a\x1a.lnrpc.GraphTopologyUpdate0\x01\x12\x41\n\nDebugLevel\x12\x18.lnrpc.DebugLevelRequest\x1a\x19.lnrpc.DebugLevelResponse\x12P\n\tFeeReport\x12\x17.lnrpc.FeeReportRequest\x1a\x18.lnrpc.FeeReportResponse\"\x10\x82\xd3\xe4\x93\x02\n\x12\x08/v1/fees\x12i\n\x13UpdateChannelPolicy\x12\x1a.lnrpc.PolicyUpdateRequest\x1a\x1b.lnrpc.PolicyUpdateResponse\"\x19\x82\xd3\xe4\x93\x02\x13\"\x0e/v1/chanpolicy:\x01*\x12m\n\x11\x46orwardingHistory\x12\x1f.lnrpc.ForwardingHistoryRequest\x1a .lnrpc.ForwardingHistoryResponse\"\x15\x82\xd3\xe4\x93\x02\x0f\"\n/v1/switch:\x01*\x12\xa3\x01\n\x13\x45xportChannelBackup\x12!.lnrpc.ExportChannelBackupRequest\x1a\x14.lnrpc.ChannelBackup\"S\x82\xd3\xe4\x93\x02M\x12K/v1/channels/backup/{chan_point.funding_txid_str}/{chan_point.output_index}\x12q\n\x17\x45xportAllChannelBackups\x12\x1e.lnrpc.ChanBackupExportRequest\x1a\x19.lnrpc.ChanBackupSnapshot\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/channels/backup\x12u\n\x10VerifyChanBackup\x12\x19.lnrpc.ChanBackupSnapshot\x1a\x1f.lnrpc.VerifyChanBackupResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v1/channels/backup/verify:\x01*\x12~\n\x15RestoreChannelBackups\x12\x1f.lnrpc.RestoreChanBackupRequest\x1a\x1c.lnrpc.RestoreBackupResponse\"&\x82\xd3\xe4\x93\x02 \"\x1b/v1/channels/backup/restore:\x01*\x12Z\n\x17SubscribeChannelBackups\x12 .lnrpc.ChannelBackupSubscription\x1a\x19.lnrpc.ChanBackupSnapshot\"\x00\x30\x01\x12`\n\x0c\x42\x61keMacaroon\x12\x1a.lnrpc.BakeMacaroonRequest\x1a\x1b.lnrpc.BakeMacaroonResponse\"\x17\x82\xd3\xe4\x93\x02\x11\"\x0c/v1/macaroon:\x01*B\'Z%github.com/lightningnetwork/lnd/lnrpcb\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,])
 
@@ -50,8 +50,8 @@ _ADDRESSTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=19900,
-  serialized_end=20025,
+  serialized_start=20220,
+  serialized_end=20345,
 )
 _sym_db.RegisterEnumDescriptor(_ADDRESSTYPE)
 
@@ -71,14 +71,14 @@ _INVOICEHTLCSTATE = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='CANCELLED', index=2, number=2,
+      name='CANCELED', index=2, number=2,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=20027,
-  serialized_end=20087,
+  serialized_start=20347,
+  serialized_end=20406,
 )
 _sym_db.RegisterEnumDescriptor(_INVOICEHTLCSTATE)
 
@@ -89,7 +89,7 @@ UNUSED_WITNESS_PUBKEY_HASH = 2
 UNUSED_NESTED_PUBKEY_HASH = 3
 ACCEPTED = 0
 SETTLED = 1
-CANCELLED = 2
+CANCELED = 2
 
 
 _CHANNELCLOSESUMMARY_CLOSURETYPE = _descriptor.EnumDescriptor(
@@ -125,8 +125,8 @@ _CHANNELCLOSESUMMARY_CLOSURETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=5594,
-  serialized_end=5732,
+  serialized_start=5658,
+  serialized_end=5796,
 )
 _sym_db.RegisterEnumDescriptor(_CHANNELCLOSESUMMARY_CLOSURETYPE)
 
@@ -151,8 +151,8 @@ _PEER_SYNCTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=6256,
-  serialized_end=6319,
+  serialized_start=6320,
+  serialized_end=6383,
 )
 _sym_db.RegisterEnumDescriptor(_PEER_SYNCTYPE)
 
@@ -181,8 +181,8 @@ _CHANNELEVENTUPDATE_UPDATETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10549,
-  serialized_end=10641,
+  serialized_start=10613,
+  serialized_end=10705,
 )
 _sym_db.RegisterEnumDescriptor(_CHANNELEVENTUPDATE_UPDATETYPE)
 
@@ -211,8 +211,8 @@ _INVOICE_INVOICESTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=15693,
-  serialized_end=15758,
+  serialized_start=15725,
+  serialized_end=15790,
 )
 _sym_db.RegisterEnumDescriptor(_INVOICE_INVOICESTATE)
 
@@ -241,8 +241,8 @@ _PAYMENT_PAYMENTSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=17072,
-  serialized_end=17142,
+  serialized_start=17108,
+  serialized_end=17178,
 )
 _sym_db.RegisterEnumDescriptor(_PAYMENT_PAYMENTSTATUS)
 
@@ -819,8 +819,8 @@ _SENDREQUEST_DESTTLVENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1646,
-  serialized_end=1692,
+  serialized_start=1650,
+  serialized_end=1696,
 )
 
 _SENDREQUEST = _descriptor.Descriptor(
@@ -892,7 +892,7 @@ _SENDREQUEST = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='cltv_limit', full_name='lnrpc.SendRequest.cltv_limit', index=9,
       number=10, type=13, cpp_type=3, label=1,
@@ -920,7 +920,7 @@ _SENDREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1348,
-  serialized_end=1692,
+  serialized_end=1696,
 )
 
 
@@ -971,8 +971,8 @@ _SENDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1695,
-  serialized_end=1879,
+  serialized_start=1699,
+  serialized_end=1883,
 )
 
 
@@ -1016,8 +1016,8 @@ _SENDTOROUTEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1881,
-  serialized_end=1987,
+  serialized_start=1885,
+  serialized_end=1991,
 )
 
 
@@ -1131,8 +1131,8 @@ _CHANNELACCEPTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1990,
-  serialized_end=2299,
+  serialized_start=1994,
+  serialized_end=2303,
 )
 
 
@@ -1169,8 +1169,8 @@ _CHANNELACCEPTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2301,
-  serialized_end=2365,
+  serialized_start=2305,
+  serialized_end=2369,
 )
 
 
@@ -1217,8 +1217,8 @@ _CHANNELPOINT = _descriptor.Descriptor(
       name='funding_txid', full_name='lnrpc.ChannelPoint.funding_txid',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2368,
-  serialized_end=2530,
+  serialized_start=2372,
+  serialized_end=2534,
 )
 
 
@@ -1262,8 +1262,8 @@ _OUTPOINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2532,
-  serialized_end=2638,
+  serialized_start=2536,
+  serialized_end=2642,
 )
 
 
@@ -1300,8 +1300,8 @@ _LIGHTNINGADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2640,
-  serialized_end=2702,
+  serialized_start=2644,
+  serialized_end=2706,
 )
 
 
@@ -1338,8 +1338,8 @@ _ESTIMATEFEEREQUEST_ADDRTOAMOUNTENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2815,
-  serialized_end=2866,
+  serialized_start=2819,
+  serialized_end=2870,
 )
 
 _ESTIMATEFEEREQUEST = _descriptor.Descriptor(
@@ -1375,8 +1375,8 @@ _ESTIMATEFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2705,
-  serialized_end=2866,
+  serialized_start=2709,
+  serialized_end=2870,
 )
 
 
@@ -1413,8 +1413,8 @@ _ESTIMATEFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2868,
-  serialized_end=2967,
+  serialized_start=2872,
+  serialized_end=2971,
 )
 
 
@@ -1451,8 +1451,8 @@ _SENDMANYREQUEST_ADDRTOAMOUNTENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2815,
-  serialized_end=2866,
+  serialized_start=2819,
+  serialized_end=2870,
 )
 
 _SENDMANYREQUEST = _descriptor.Descriptor(
@@ -1495,8 +1495,8 @@ _SENDMANYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2970,
-  serialized_end=3147,
+  serialized_start=2974,
+  serialized_end=3151,
 )
 
 
@@ -1526,8 +1526,8 @@ _SENDMANYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3149,
-  serialized_end=3187,
+  serialized_start=3153,
+  serialized_end=3191,
 )
 
 
@@ -1585,8 +1585,8 @@ _SENDCOINSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3189,
-  serialized_end=3298,
+  serialized_start=3193,
+  serialized_end=3302,
 )
 
 
@@ -1616,8 +1616,8 @@ _SENDCOINSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3300,
-  serialized_end=3339,
+  serialized_start=3304,
+  serialized_end=3343,
 )
 
 
@@ -1654,8 +1654,8 @@ _LISTUNSPENTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3341,
-  serialized_end=3399,
+  serialized_start=3345,
+  serialized_end=3403,
 )
 
 
@@ -1685,8 +1685,8 @@ _LISTUNSPENTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3401,
-  serialized_end=3457,
+  serialized_start=3405,
+  serialized_end=3461,
 )
 
 
@@ -1716,8 +1716,8 @@ _NEWADDRESSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3459,
-  serialized_end=3512,
+  serialized_start=3463,
+  serialized_end=3516,
 )
 
 
@@ -1747,8 +1747,8 @@ _NEWADDRESSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3514,
-  serialized_end=3560,
+  serialized_start=3518,
+  serialized_end=3564,
 )
 
 
@@ -1778,8 +1778,8 @@ _SIGNMESSAGEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3562,
-  serialized_end=3600,
+  serialized_start=3566,
+  serialized_end=3604,
 )
 
 
@@ -1809,8 +1809,8 @@ _SIGNMESSAGERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3602,
-  serialized_end=3653,
+  serialized_start=3606,
+  serialized_end=3657,
 )
 
 
@@ -1847,8 +1847,8 @@ _VERIFYMESSAGEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3655,
-  serialized_end=3725,
+  serialized_start=3659,
+  serialized_end=3729,
 )
 
 
@@ -1885,8 +1885,8 @@ _VERIFYMESSAGERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3727,
-  serialized_end=3796,
+  serialized_start=3731,
+  serialized_end=3800,
 )
 
 
@@ -1923,8 +1923,8 @@ _CONNECTPEERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3798,
-  serialized_end=3871,
+  serialized_start=3802,
+  serialized_end=3875,
 )
 
 
@@ -1947,8 +1947,8 @@ _CONNECTPEERRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3873,
-  serialized_end=3894,
+  serialized_start=3877,
+  serialized_end=3898,
 )
 
 
@@ -1978,8 +1978,8 @@ _DISCONNECTPEERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3896,
-  serialized_end=3945,
+  serialized_start=3900,
+  serialized_end=3949,
 )
 
 
@@ -2002,8 +2002,8 @@ _DISCONNECTPEERRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3947,
-  serialized_end=3971,
+  serialized_start=3951,
+  serialized_end=3975,
 )
 
 
@@ -2054,8 +2054,8 @@ _HTLC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3974,
-  serialized_end=4108,
+  serialized_start=3978,
+  serialized_end=4112,
 )
 
 
@@ -2093,7 +2093,7 @@ _CHANNEL = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='capacity', full_name='lnrpc.Channel.capacity', index=4,
       number=5, type=3, cpp_type=2, label=1,
@@ -2220,6 +2220,20 @@ _CHANNEL = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, json_name='static_remote_key', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='lifetime', full_name='lnrpc.Channel.lifetime', index=22,
+      number=23, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='lifetime', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='uptime', full_name='lnrpc.Channel.uptime', index=23,
+      number=24, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='uptime', file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -2232,8 +2246,8 @@ _CHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4111,
-  serialized_end=4985,
+  serialized_start=4115,
+  serialized_end=5045,
 )
 
 
@@ -2284,8 +2298,8 @@ _LISTCHANNELSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4987,
-  serialized_end=5095,
+  serialized_start=5047,
+  serialized_end=5155,
 )
 
 
@@ -2315,8 +2329,8 @@ _LISTCHANNELSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5097,
-  serialized_end=5163,
+  serialized_start=5157,
+  serialized_end=5223,
 )
 
 
@@ -2340,7 +2354,7 @@ _CHANNELCLOSESUMMARY = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='chain_hash', full_name='lnrpc.ChannelCloseSummary.chain_hash', index=2,
       number=3, type=9, cpp_type=9, label=1,
@@ -2410,8 +2424,8 @@ _CHANNELCLOSESUMMARY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5166,
-  serialized_end=5732,
+  serialized_start=5226,
+  serialized_end=5796,
 )
 
 
@@ -2476,8 +2490,8 @@ _CLOSEDCHANNELSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5735,
-  serialized_end=5883,
+  serialized_start=5799,
+  serialized_end=5947,
 )
 
 
@@ -2507,8 +2521,8 @@ _CLOSEDCHANNELSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5885,
-  serialized_end=5965,
+  serialized_start=5949,
+  serialized_end=6029,
 )
 
 
@@ -2595,8 +2609,8 @@ _PEER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5968,
-  serialized_end=6319,
+  serialized_start=6032,
+  serialized_end=6383,
 )
 
 
@@ -2619,8 +2633,8 @@ _LISTPEERSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6321,
-  serialized_end=6339,
+  serialized_start=6385,
+  serialized_end=6403,
 )
 
 
@@ -2650,8 +2664,8 @@ _LISTPEERSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6341,
-  serialized_end=6395,
+  serialized_start=6405,
+  serialized_end=6459,
 )
 
 
@@ -2674,8 +2688,8 @@ _GETINFOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6397,
-  serialized_end=6413,
+  serialized_start=6461,
+  serialized_end=6477,
 )
 
 
@@ -2810,8 +2824,8 @@ _GETINFORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6416,
-  serialized_end=7031,
+  serialized_start=6480,
+  serialized_end=7095,
 )
 
 
@@ -2848,8 +2862,8 @@ _CHAIN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7033,
-  serialized_end=7088,
+  serialized_start=7097,
+  serialized_end=7152,
 )
 
 
@@ -2893,8 +2907,8 @@ _CONFIRMATIONUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7090,
-  serialized_end=7175,
+  serialized_start=7154,
+  serialized_end=7239,
 )
 
 
@@ -2924,8 +2938,8 @@ _CHANNELOPENUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7177,
-  serialized_end=7255,
+  serialized_start=7241,
+  serialized_end=7319,
 )
 
 
@@ -2962,8 +2976,8 @@ _CHANNELCLOSEUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7257,
-  serialized_end=7339,
+  serialized_start=7321,
+  serialized_end=7403,
 )
 
 
@@ -3014,8 +3028,8 @@ _CLOSECHANNELREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7341,
-  serialized_end=7464,
+  serialized_start=7405,
+  serialized_end=7528,
 )
 
 
@@ -3055,8 +3069,8 @@ _CLOSESTATUSUPDATE = _descriptor.Descriptor(
       name='update', full_name='lnrpc.CloseStatusUpdate.update',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=7467,
-  serialized_end=7619,
+  serialized_start=7531,
+  serialized_end=7683,
 )
 
 
@@ -3093,8 +3107,8 @@ _PENDINGUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7621,
-  serialized_end=7692,
+  serialized_start=7685,
+  serialized_end=7756,
 )
 
 
@@ -3194,8 +3208,8 @@ _OPENCHANNELREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7695,
-  serialized_end=8104,
+  serialized_start=7759,
+  serialized_end=8168,
 )
 
 
@@ -3235,8 +3249,8 @@ _OPENSTATUSUPDATE = _descriptor.Descriptor(
       name='update', full_name='lnrpc.OpenStatusUpdate.update',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=8107,
-  serialized_end=8253,
+  serialized_start=8171,
+  serialized_end=8317,
 )
 
 
@@ -3301,8 +3315,8 @@ _PENDINGHTLC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8256,
-  serialized_end=8463,
+  serialized_start=8320,
+  serialized_end=8527,
 )
 
 
@@ -3325,8 +3339,8 @@ _PENDINGCHANNELSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8465,
-  serialized_end=8489,
+  serialized_start=8529,
+  serialized_end=8553,
 )
 
 
@@ -3398,8 +3412,8 @@ _PENDINGCHANNELSRESPONSE_PENDINGCHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9012,
-  serialized_end=9328,
+  serialized_start=9076,
+  serialized_end=9392,
 )
 
 _PENDINGCHANNELSRESPONSE_PENDINGOPENCHANNEL = _descriptor.Descriptor(
@@ -3456,8 +3470,8 @@ _PENDINGCHANNELSRESPONSE_PENDINGOPENCHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9331,
-  serialized_end=9576,
+  serialized_start=9395,
+  serialized_end=9640,
 )
 
 _PENDINGCHANNELSRESPONSE_WAITINGCLOSECHANNEL = _descriptor.Descriptor(
@@ -3493,8 +3507,8 @@ _PENDINGCHANNELSRESPONSE_WAITINGCLOSECHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9578,
-  serialized_end=9701,
+  serialized_start=9642,
+  serialized_end=9765,
 )
 
 _PENDINGCHANNELSRESPONSE_CLOSEDCHANNEL = _descriptor.Descriptor(
@@ -3530,8 +3544,8 @@ _PENDINGCHANNELSRESPONSE_CLOSEDCHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9703,
-  serialized_end=9818,
+  serialized_start=9767,
+  serialized_end=9882,
 )
 
 _PENDINGCHANNELSRESPONSE_FORCECLOSEDCHANNEL = _descriptor.Descriptor(
@@ -3602,8 +3616,8 @@ _PENDINGCHANNELSRESPONSE_FORCECLOSEDCHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9821,
-  serialized_end=10184,
+  serialized_start=9885,
+  serialized_end=10248,
 )
 
 _PENDINGCHANNELSRESPONSE = _descriptor.Descriptor(
@@ -3660,8 +3674,8 @@ _PENDINGCHANNELSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8492,
-  serialized_end=10184,
+  serialized_start=8556,
+  serialized_end=10248,
 )
 
 
@@ -3684,8 +3698,8 @@ _CHANNELEVENTSUBSCRIPTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10186,
-  serialized_end=10212,
+  serialized_start=10250,
+  serialized_end=10276,
 )
 
 
@@ -3747,8 +3761,8 @@ _CHANNELEVENTUPDATE = _descriptor.Descriptor(
       name='channel', full_name='lnrpc.ChannelEventUpdate.channel',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=10215,
-  serialized_end=10652,
+  serialized_start=10279,
+  serialized_end=10716,
 )
 
 
@@ -3771,8 +3785,8 @@ _WALLETBALANCEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10654,
-  serialized_end=10676,
+  serialized_start=10718,
+  serialized_end=10740,
 )
 
 
@@ -3816,8 +3830,8 @@ _WALLETBALANCERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10679,
-  serialized_end=10836,
+  serialized_start=10743,
+  serialized_end=10900,
 )
 
 
@@ -3840,8 +3854,8 @@ _CHANNELBALANCEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10838,
-  serialized_end=10861,
+  serialized_start=10902,
+  serialized_end=10925,
 )
 
 
@@ -3878,47 +3892,10 @@ _CHANNELBALANCERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10863,
-  serialized_end=10965,
+  serialized_start=10927,
+  serialized_end=11029,
 )
 
-
-_QUERYROUTESREQUEST_DESTTLVENTRY = _descriptor.Descriptor(
-  name='DestTlvEntry',
-  full_name='lnrpc.QueryRoutesRequest.DestTlvEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='lnrpc.QueryRoutesRequest.DestTlvEntry.key', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='lnrpc.QueryRoutesRequest.DestTlvEntry.value', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1646,
-  serialized_end=1692,
-)
 
 _QUERYROUTESREQUEST = _descriptor.Descriptor(
   name='QueryRoutesRequest',
@@ -3991,16 +3968,16 @@ _QUERYROUTESREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='dest_tlv', full_name='lnrpc.QueryRoutesRequest.dest_tlv', index=9,
-      number=11, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
+      name='cltv_limit', full_name='lnrpc.QueryRoutesRequest.cltv_limit', index=9,
+      number=11, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
-  nested_types=[_QUERYROUTESREQUEST_DESTTLVENTRY, ],
+  nested_types=[],
   enum_types=[
   ],
   options=None,
@@ -4009,8 +3986,8 @@ _QUERYROUTESREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10968,
-  serialized_end=11355,
+  serialized_start=11032,
+  serialized_end=11333,
 )
 
 
@@ -4047,8 +4024,8 @@ _NODEPAIR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11357,
-  serialized_end=11393,
+  serialized_start=11335,
+  serialized_end=11371,
 )
 
 
@@ -4065,7 +4042,7 @@ _EDGELOCATOR = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='direction_reverse', full_name='lnrpc.EdgeLocator.direction_reverse', index=1,
       number=2, type=8, cpp_type=7, label=1,
@@ -4085,8 +4062,8 @@ _EDGELOCATOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11395,
-  serialized_end=11455,
+  serialized_start=11373,
+  serialized_end=11437,
 )
 
 
@@ -4123,47 +4100,10 @@ _QUERYROUTESRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11457,
-  serialized_end=11552,
+  serialized_start=11439,
+  serialized_end=11534,
 )
 
-
-_HOP_TLVRECORDSENTRY = _descriptor.Descriptor(
-  name='TlvRecordsEntry',
-  full_name='lnrpc.Hop.TlvRecordsEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='lnrpc.Hop.TlvRecordsEntry.key', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='lnrpc.Hop.TlvRecordsEntry.value', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=11916,
-  serialized_end=11965,
-)
 
 _HOP = _descriptor.Descriptor(
   name='Hop',
@@ -4178,7 +4118,7 @@ _HOP = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='chan_capacity', full_name='lnrpc.Hop.chan_capacity', index=1,
       number=2, type=3, cpp_type=2, label=1,
@@ -4236,16 +4176,16 @@ _HOP = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None, json_name='tlv_payload', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='tlv_records', full_name='lnrpc.Hop.tlv_records', index=9,
-      number=10, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
+      name='mpp_record', full_name='lnrpc.Hop.mpp_record', index=9,
+      number=10, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='tlv_records', file=DESCRIPTOR),
+      options=None, json_name='mpp_record', file=DESCRIPTOR),
   ],
   extensions=[
   ],
-  nested_types=[_HOP_TLVRECORDSENTRY, ],
+  nested_types=[],
   enum_types=[
   ],
   options=None,
@@ -4254,8 +4194,46 @@ _HOP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11555,
-  serialized_end=11965,
+  serialized_start=11537,
+  serialized_end=11888,
+)
+
+
+_MPPRECORD = _descriptor.Descriptor(
+  name='MPPRecord',
+  full_name='lnrpc.MPPRecord',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='payment_addr', full_name='lnrpc.MPPRecord.payment_addr', index=0,
+      number=11, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='payment_addr', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='total_amt_msat', full_name='lnrpc.MPPRecord.total_amt_msat', index=1,
+      number=10, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='total_amt_msat', file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11890,
+  serialized_end=11977,
 )
 
 
@@ -4320,8 +4298,8 @@ _ROUTE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11968,
-  serialized_end=12201,
+  serialized_start=11980,
+  serialized_end=12213,
 )
 
 
@@ -4358,8 +4336,8 @@ _NODEINFOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=12203,
-  serialized_end=12263,
+  serialized_start=12215,
+  serialized_end=12275,
 )
 
 
@@ -4410,8 +4388,8 @@ _NODEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=12266,
-  serialized_end=12442,
+  serialized_start=12278,
+  serialized_end=12454,
 )
 
 
@@ -4469,8 +4447,8 @@ _LIGHTNINGNODE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=12445,
-  serialized_end=12614,
+  serialized_start=12457,
+  serialized_end=12626,
 )
 
 
@@ -4507,8 +4485,8 @@ _NODEADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=12616,
-  serialized_end=12675,
+  serialized_start=12628,
+  serialized_end=12687,
 )
 
 
@@ -4580,8 +4558,8 @@ _ROUTINGPOLICY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=12678,
-  serialized_end=12951,
+  serialized_start=12690,
+  serialized_end=12963,
 )
 
 
@@ -4598,7 +4576,7 @@ _CHANNELEDGE = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='channel_id', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='channel_id', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='chan_point', full_name='lnrpc.ChannelEdge.chan_point', index=1,
       number=2, type=9, cpp_type=9, label=1,
@@ -4660,8 +4638,8 @@ _CHANNELEDGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=12954,
-  serialized_end=13273,
+  serialized_start=12966,
+  serialized_end=13289,
 )
 
 
@@ -4691,8 +4669,8 @@ _CHANNELGRAPHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13275,
-  serialized_end=13346,
+  serialized_start=13291,
+  serialized_end=13362,
 )
 
 
@@ -4729,8 +4707,8 @@ _CHANNELGRAPH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13348,
-  serialized_end=13448,
+  serialized_start=13364,
+  serialized_end=13464,
 )
 
 
@@ -4747,7 +4725,7 @@ _CHANINFOREQUEST = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -4760,8 +4738,8 @@ _CHANINFOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13450,
-  serialized_end=13484,
+  serialized_start=13466,
+  serialized_end=13504,
 )
 
 
@@ -4784,8 +4762,8 @@ _NETWORKINFOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13486,
-  serialized_end=13506,
+  serialized_start=13506,
+  serialized_end=13526,
 )
 
 
@@ -4885,8 +4863,8 @@ _NETWORKINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13509,
-  serialized_end=13998,
+  serialized_start=13529,
+  serialized_end=14018,
 )
 
 
@@ -4909,8 +4887,8 @@ _STOPREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14000,
-  serialized_end=14013,
+  serialized_start=14020,
+  serialized_end=14033,
 )
 
 
@@ -4933,8 +4911,8 @@ _STOPRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14015,
-  serialized_end=14029,
+  serialized_start=14035,
+  serialized_end=14049,
 )
 
 
@@ -4957,8 +4935,8 @@ _GRAPHTOPOLOGYSUBSCRIPTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14031,
-  serialized_end=14058,
+  serialized_start=14051,
+  serialized_end=14078,
 )
 
 
@@ -5002,8 +4980,8 @@ _GRAPHTOPOLOGYUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14061,
-  serialized_end=14224,
+  serialized_start=14081,
+  serialized_end=14244,
 )
 
 
@@ -5061,8 +5039,8 @@ _NODEUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14226,
-  serialized_end=14334,
+  serialized_start=14246,
+  serialized_end=14354,
 )
 
 
@@ -5079,7 +5057,7 @@ _CHANNELEDGEUPDATE = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='chan_point', full_name='lnrpc.ChannelEdgeUpdate.chan_point', index=1,
       number=2, type=11, cpp_type=10, label=1,
@@ -5127,8 +5105,8 @@ _CHANNELEDGEUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14337,
-  serialized_end=14529,
+  serialized_start=14357,
+  serialized_end=14553,
 )
 
 
@@ -5145,7 +5123,7 @@ _CLOSEDCHANNELUPDATE = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='capacity', full_name='lnrpc.ClosedChannelUpdate.capacity', index=1,
       number=2, type=3, cpp_type=2, label=1,
@@ -5179,8 +5157,8 @@ _CLOSEDCHANNELUPDATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14531,
-  serialized_end=14651,
+  serialized_start=14555,
+  serialized_end=14679,
 )
 
 
@@ -5204,7 +5182,7 @@ _HOPHINT = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='fee_base_msat', full_name='lnrpc.HopHint.fee_base_msat', index=2,
       number=3, type=13, cpp_type=3, label=1,
@@ -5238,8 +5216,8 @@ _HOPHINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14654,
-  serialized_end=14865,
+  serialized_start=14682,
+  serialized_end=14897,
 )
 
 
@@ -5269,8 +5247,8 @@ _ROUTEHINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14867,
-  serialized_end=14924,
+  serialized_start=14899,
+  serialized_end=14956,
 )
 
 
@@ -5448,8 +5426,8 @@ _INVOICE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=14927,
-  serialized_end=15758,
+  serialized_start=14959,
+  serialized_end=15790,
 )
 
 
@@ -5466,7 +5444,7 @@ _INVOICEHTLC = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='htlc_index', full_name='lnrpc.InvoiceHTLC.htlc_index', index=1,
       number=2, type=4, cpp_type=4, label=1,
@@ -5528,8 +5506,8 @@ _INVOICEHTLC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=15761,
-  serialized_end=16053,
+  serialized_start=15793,
+  serialized_end=16089,
 )
 
 
@@ -5573,8 +5551,8 @@ _ADDINVOICERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16055,
-  serialized_end=16171,
+  serialized_start=16091,
+  serialized_end=16207,
 )
 
 
@@ -5611,8 +5589,8 @@ _PAYMENTHASH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16173,
-  serialized_end=16242,
+  serialized_start=16209,
+  serialized_end=16278,
 )
 
 
@@ -5663,8 +5641,8 @@ _LISTINVOICEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16245,
-  serialized_end=16409,
+  serialized_start=16281,
+  serialized_end=16445,
 )
 
 
@@ -5708,8 +5686,8 @@ _LISTINVOICERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16412,
-  serialized_end=16571,
+  serialized_start=16448,
+  serialized_end=16607,
 )
 
 
@@ -5746,8 +5724,8 @@ _INVOICESUBSCRIPTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16573,
-  serialized_end=16660,
+  serialized_start=16609,
+  serialized_end=16696,
 )
 
 
@@ -5855,8 +5833,8 @@ _PAYMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16663,
-  serialized_end=17142,
+  serialized_start=16699,
+  serialized_end=17178,
 )
 
 
@@ -5886,8 +5864,8 @@ _LISTPAYMENTSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17144,
-  serialized_end=17193,
+  serialized_start=17180,
+  serialized_end=17229,
 )
 
 
@@ -5917,8 +5895,8 @@ _LISTPAYMENTSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17195,
-  serialized_end=17261,
+  serialized_start=17231,
+  serialized_end=17297,
 )
 
 
@@ -5941,8 +5919,8 @@ _DELETEALLPAYMENTSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17263,
-  serialized_end=17289,
+  serialized_start=17299,
+  serialized_end=17325,
 )
 
 
@@ -5965,8 +5943,8 @@ _DELETEALLPAYMENTSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17291,
-  serialized_end=17318,
+  serialized_start=17327,
+  serialized_end=17354,
 )
 
 
@@ -5996,8 +5974,8 @@ _ABANDONCHANNELREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17320,
-  serialized_end=17387,
+  serialized_start=17356,
+  serialized_end=17423,
 )
 
 
@@ -6020,8 +5998,8 @@ _ABANDONCHANNELRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17389,
-  serialized_end=17413,
+  serialized_start=17425,
+  serialized_end=17449,
 )
 
 
@@ -6058,8 +6036,8 @@ _DEBUGLEVELREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17415,
-  serialized_end=17468,
+  serialized_start=17451,
+  serialized_end=17504,
 )
 
 
@@ -6089,8 +6067,8 @@ _DEBUGLEVELRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17470,
-  serialized_end=17524,
+  serialized_start=17506,
+  serialized_end=17560,
 )
 
 
@@ -6120,8 +6098,8 @@ _PAYREQSTRING = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17526,
-  serialized_end=17557,
+  serialized_start=17562,
+  serialized_end=17593,
 )
 
 
@@ -6214,8 +6192,8 @@ _PAYREQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17560,
-  serialized_end=17930,
+  serialized_start=17596,
+  serialized_end=17966,
 )
 
 
@@ -6238,8 +6216,8 @@ _FEEREPORTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17932,
-  serialized_end=17950,
+  serialized_start=17968,
+  serialized_end=17986,
 )
 
 
@@ -6290,8 +6268,8 @@ _CHANNELFEEREPORT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17953,
-  serialized_end=18106,
+  serialized_start=17989,
+  serialized_end=18142,
 )
 
 
@@ -6342,8 +6320,8 @@ _FEEREPORTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18109,
-  serialized_end=18297,
+  serialized_start=18145,
+  serialized_end=18333,
 )
 
 
@@ -6411,8 +6389,8 @@ _POLICYUPDATEREQUEST = _descriptor.Descriptor(
       name='scope', full_name='lnrpc.PolicyUpdateRequest.scope',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=18300,
-  serialized_end=18557,
+  serialized_start=18336,
+  serialized_end=18593,
 )
 
 
@@ -6435,8 +6413,8 @@ _POLICYUPDATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18559,
-  serialized_end=18581,
+  serialized_start=18595,
+  serialized_end=18617,
 )
 
 
@@ -6487,8 +6465,8 @@ _FORWARDINGHISTORYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18584,
-  serialized_end=18746,
+  serialized_start=18620,
+  serialized_end=18782,
 )
 
 
@@ -6512,14 +6490,14 @@ _FORWARDINGEVENT = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id_in', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id_in', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='chan_id_out', full_name='lnrpc.ForwardingEvent.chan_id_out', index=2,
       number=4, type=4, cpp_type=4, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, json_name='chan_id_out', file=DESCRIPTOR),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001')), json_name='chan_id_out', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='amt_in', full_name='lnrpc.ForwardingEvent.amt_in', index=3,
       number=5, type=4, cpp_type=4, label=1,
@@ -6548,6 +6526,20 @@ _FORWARDINGEVENT = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, json_name='fee_msat', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='amt_in_msat', full_name='lnrpc.ForwardingEvent.amt_in_msat', index=7,
+      number=9, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='amt_in_msat', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='amt_out_msat', full_name='lnrpc.ForwardingEvent.amt_out_msat', index=8,
+      number=10, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='amt_out_msat', file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -6560,8 +6552,8 @@ _FORWARDINGEVENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18749,
-  serialized_end=18958,
+  serialized_start=18785,
+  serialized_end=19072,
 )
 
 
@@ -6598,8 +6590,8 @@ _FORWARDINGHISTORYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18961,
-  serialized_end=19104,
+  serialized_start=19075,
+  serialized_end=19218,
 )
 
 
@@ -6629,8 +6621,8 @@ _EXPORTCHANNELBACKUPREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19106,
-  serialized_end=19175,
+  serialized_start=19220,
+  serialized_end=19289,
 )
 
 
@@ -6667,8 +6659,8 @@ _CHANNELBACKUP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19177,
-  serialized_end=19279,
+  serialized_start=19291,
+  serialized_end=19393,
 )
 
 
@@ -6705,8 +6697,8 @@ _MULTICHANBACKUP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19281,
-  serialized_end=19399,
+  serialized_start=19395,
+  serialized_end=19513,
 )
 
 
@@ -6729,8 +6721,8 @@ _CHANBACKUPEXPORTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19401,
-  serialized_end=19426,
+  serialized_start=19515,
+  serialized_end=19540,
 )
 
 
@@ -6767,8 +6759,8 @@ _CHANBACKUPSNAPSHOT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19429,
-  serialized_end=19592,
+  serialized_start=19543,
+  serialized_end=19706,
 )
 
 
@@ -6798,8 +6790,8 @@ _CHANNELBACKUPS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19594,
-  serialized_end=19668,
+  serialized_start=19708,
+  serialized_end=19782,
 )
 
 
@@ -6839,8 +6831,8 @@ _RESTORECHANBACKUPREQUEST = _descriptor.Descriptor(
       name='backup', full_name='lnrpc.RestoreChanBackupRequest.backup',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=19671,
-  serialized_end=19816,
+  serialized_start=19785,
+  serialized_end=19930,
 )
 
 
@@ -6863,8 +6855,8 @@ _RESTOREBACKUPRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19818,
-  serialized_end=19841,
+  serialized_start=19932,
+  serialized_end=19955,
 )
 
 
@@ -6887,8 +6879,8 @@ _CHANNELBACKUPSUBSCRIPTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19843,
-  serialized_end=19870,
+  serialized_start=19957,
+  serialized_end=19984,
 )
 
 
@@ -6911,8 +6903,108 @@ _VERIFYCHANBACKUPRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=19872,
-  serialized_end=19898,
+  serialized_start=19986,
+  serialized_end=20012,
+)
+
+
+_MACAROONPERMISSION = _descriptor.Descriptor(
+  name='MacaroonPermission',
+  full_name='lnrpc.MacaroonPermission',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='entity', full_name='lnrpc.MacaroonPermission.entity', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='entity', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='action', full_name='lnrpc.MacaroonPermission.action', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='action', file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=20014,
+  serialized_end=20082,
+)
+
+
+_BAKEMACAROONREQUEST = _descriptor.Descriptor(
+  name='BakeMacaroonRequest',
+  full_name='lnrpc.BakeMacaroonRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='permissions', full_name='lnrpc.BakeMacaroonRequest.permissions', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='permissions', file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=20084,
+  serialized_end=20166,
+)
+
+
+_BAKEMACAROONRESPONSE = _descriptor.Descriptor(
+  name='BakeMacaroonResponse',
+  full_name='lnrpc.BakeMacaroonResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='macaroon', full_name='lnrpc.BakeMacaroonResponse.macaroon', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, json_name='macaroon', file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=20168,
+  serialized_end=20218,
 )
 
 _INITWALLETREQUEST.fields_by_name['channel_backups'].message_type = _CHANBACKUPSNAPSHOT
@@ -7003,14 +7095,11 @@ _CHANNELEVENTUPDATE.fields_by_name['active_channel'].containing_oneof = _CHANNEL
 _CHANNELEVENTUPDATE.oneofs_by_name['channel'].fields.append(
   _CHANNELEVENTUPDATE.fields_by_name['inactive_channel'])
 _CHANNELEVENTUPDATE.fields_by_name['inactive_channel'].containing_oneof = _CHANNELEVENTUPDATE.oneofs_by_name['channel']
-_QUERYROUTESREQUEST_DESTTLVENTRY.containing_type = _QUERYROUTESREQUEST
 _QUERYROUTESREQUEST.fields_by_name['fee_limit'].message_type = _FEELIMIT
 _QUERYROUTESREQUEST.fields_by_name['ignored_edges'].message_type = _EDGELOCATOR
 _QUERYROUTESREQUEST.fields_by_name['ignored_pairs'].message_type = _NODEPAIR
-_QUERYROUTESREQUEST.fields_by_name['dest_tlv'].message_type = _QUERYROUTESREQUEST_DESTTLVENTRY
 _QUERYROUTESRESPONSE.fields_by_name['routes'].message_type = _ROUTE
-_HOP_TLVRECORDSENTRY.containing_type = _HOP
-_HOP.fields_by_name['tlv_records'].message_type = _HOP_TLVRECORDSENTRY
+_HOP.fields_by_name['mpp_record'].message_type = _MPPRECORD
 _ROUTE.fields_by_name['hops'].message_type = _HOP
 _NODEINFO.fields_by_name['node'].message_type = _LIGHTNINGNODE
 _NODEINFO.fields_by_name['channels'].message_type = _CHANNELEDGE
@@ -7059,6 +7148,7 @@ _RESTORECHANBACKUPREQUEST.fields_by_name['chan_backups'].containing_oneof = _RES
 _RESTORECHANBACKUPREQUEST.oneofs_by_name['backup'].fields.append(
   _RESTORECHANBACKUPREQUEST.fields_by_name['multi_chan_backup'])
 _RESTORECHANBACKUPREQUEST.fields_by_name['multi_chan_backup'].containing_oneof = _RESTORECHANBACKUPREQUEST.oneofs_by_name['backup']
+_BAKEMACAROONREQUEST.fields_by_name['permissions'].message_type = _MACAROONPERMISSION
 DESCRIPTOR.message_types_by_name['GenSeedRequest'] = _GENSEEDREQUEST
 DESCRIPTOR.message_types_by_name['GenSeedResponse'] = _GENSEEDRESPONSE
 DESCRIPTOR.message_types_by_name['InitWalletRequest'] = _INITWALLETREQUEST
@@ -7133,6 +7223,7 @@ DESCRIPTOR.message_types_by_name['NodePair'] = _NODEPAIR
 DESCRIPTOR.message_types_by_name['EdgeLocator'] = _EDGELOCATOR
 DESCRIPTOR.message_types_by_name['QueryRoutesResponse'] = _QUERYROUTESRESPONSE
 DESCRIPTOR.message_types_by_name['Hop'] = _HOP
+DESCRIPTOR.message_types_by_name['MPPRecord'] = _MPPRECORD
 DESCRIPTOR.message_types_by_name['Route'] = _ROUTE
 DESCRIPTOR.message_types_by_name['NodeInfoRequest'] = _NODEINFOREQUEST
 DESCRIPTOR.message_types_by_name['NodeInfo'] = _NODEINFO
@@ -7190,6 +7281,9 @@ DESCRIPTOR.message_types_by_name['RestoreChanBackupRequest'] = _RESTORECHANBACKU
 DESCRIPTOR.message_types_by_name['RestoreBackupResponse'] = _RESTOREBACKUPRESPONSE
 DESCRIPTOR.message_types_by_name['ChannelBackupSubscription'] = _CHANNELBACKUPSUBSCRIPTION
 DESCRIPTOR.message_types_by_name['VerifyChanBackupResponse'] = _VERIFYCHANBACKUPRESPONSE
+DESCRIPTOR.message_types_by_name['MacaroonPermission'] = _MACAROONPERMISSION
+DESCRIPTOR.message_types_by_name['BakeMacaroonRequest'] = _BAKEMACAROONREQUEST
+DESCRIPTOR.message_types_by_name['BakeMacaroonResponse'] = _BAKEMACAROONRESPONSE
 DESCRIPTOR.enum_types_by_name['AddressType'] = _ADDRESSTYPE
 DESCRIPTOR.enum_types_by_name['InvoiceHTLCState'] = _INVOICEHTLCSTATE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -7742,19 +7836,11 @@ ChannelBalanceResponse = _reflection.GeneratedProtocolMessageType('ChannelBalanc
 _sym_db.RegisterMessage(ChannelBalanceResponse)
 
 QueryRoutesRequest = _reflection.GeneratedProtocolMessageType('QueryRoutesRequest', (_message.Message,), dict(
-
-  DestTlvEntry = _reflection.GeneratedProtocolMessageType('DestTlvEntry', (_message.Message,), dict(
-    DESCRIPTOR = _QUERYROUTESREQUEST_DESTTLVENTRY,
-    __module__ = 'rpc_pb2'
-    # @@protoc_insertion_point(class_scope:lnrpc.QueryRoutesRequest.DestTlvEntry)
-    ))
-  ,
   DESCRIPTOR = _QUERYROUTESREQUEST,
   __module__ = 'rpc_pb2'
   # @@protoc_insertion_point(class_scope:lnrpc.QueryRoutesRequest)
   ))
 _sym_db.RegisterMessage(QueryRoutesRequest)
-_sym_db.RegisterMessage(QueryRoutesRequest.DestTlvEntry)
 
 NodePair = _reflection.GeneratedProtocolMessageType('NodePair', (_message.Message,), dict(
   DESCRIPTOR = _NODEPAIR,
@@ -7778,19 +7864,18 @@ QueryRoutesResponse = _reflection.GeneratedProtocolMessageType('QueryRoutesRespo
 _sym_db.RegisterMessage(QueryRoutesResponse)
 
 Hop = _reflection.GeneratedProtocolMessageType('Hop', (_message.Message,), dict(
-
-  TlvRecordsEntry = _reflection.GeneratedProtocolMessageType('TlvRecordsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _HOP_TLVRECORDSENTRY,
-    __module__ = 'rpc_pb2'
-    # @@protoc_insertion_point(class_scope:lnrpc.Hop.TlvRecordsEntry)
-    ))
-  ,
   DESCRIPTOR = _HOP,
   __module__ = 'rpc_pb2'
   # @@protoc_insertion_point(class_scope:lnrpc.Hop)
   ))
 _sym_db.RegisterMessage(Hop)
-_sym_db.RegisterMessage(Hop.TlvRecordsEntry)
+
+MPPRecord = _reflection.GeneratedProtocolMessageType('MPPRecord', (_message.Message,), dict(
+  DESCRIPTOR = _MPPRECORD,
+  __module__ = 'rpc_pb2'
+  # @@protoc_insertion_point(class_scope:lnrpc.MPPRecord)
+  ))
+_sym_db.RegisterMessage(MPPRecord)
 
 Route = _reflection.GeneratedProtocolMessageType('Route', (_message.Message,), dict(
   DESCRIPTOR = _ROUTE,
@@ -8191,23 +8276,50 @@ VerifyChanBackupResponse = _reflection.GeneratedProtocolMessageType('VerifyChanB
   ))
 _sym_db.RegisterMessage(VerifyChanBackupResponse)
 
+MacaroonPermission = _reflection.GeneratedProtocolMessageType('MacaroonPermission', (_message.Message,), dict(
+  DESCRIPTOR = _MACAROONPERMISSION,
+  __module__ = 'rpc_pb2'
+  # @@protoc_insertion_point(class_scope:lnrpc.MacaroonPermission)
+  ))
+_sym_db.RegisterMessage(MacaroonPermission)
+
+BakeMacaroonRequest = _reflection.GeneratedProtocolMessageType('BakeMacaroonRequest', (_message.Message,), dict(
+  DESCRIPTOR = _BAKEMACAROONREQUEST,
+  __module__ = 'rpc_pb2'
+  # @@protoc_insertion_point(class_scope:lnrpc.BakeMacaroonRequest)
+  ))
+_sym_db.RegisterMessage(BakeMacaroonRequest)
+
+BakeMacaroonResponse = _reflection.GeneratedProtocolMessageType('BakeMacaroonResponse', (_message.Message,), dict(
+  DESCRIPTOR = _BAKEMACAROONRESPONSE,
+  __module__ = 'rpc_pb2'
+  # @@protoc_insertion_point(class_scope:lnrpc.BakeMacaroonResponse)
+  ))
+_sym_db.RegisterMessage(BakeMacaroonResponse)
+
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('Z%github.com/lightningnetwork/lnd/lnrpc'))
 _SENDREQUEST_DESTTLVENTRY.has_options = True
 _SENDREQUEST_DESTTLVENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_SENDREQUEST.fields_by_name['outgoing_chan_id'].has_options = True
+_SENDREQUEST.fields_by_name['outgoing_chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 _ESTIMATEFEEREQUEST_ADDRTOAMOUNTENTRY.has_options = True
 _ESTIMATEFEEREQUEST_ADDRTOAMOUNTENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 _SENDMANYREQUEST_ADDRTOAMOUNTENTRY.has_options = True
 _SENDMANYREQUEST_ADDRTOAMOUNTENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_CHANNEL.fields_by_name['chan_id'].has_options = True
+_CHANNEL.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
+_CHANNELCLOSESUMMARY.fields_by_name['chan_id'].has_options = True
+_CHANNELCLOSESUMMARY.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 _GETINFORESPONSE.fields_by_name['testnet'].has_options = True
 _GETINFORESPONSE.fields_by_name['testnet']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
-_QUERYROUTESREQUEST_DESTTLVENTRY.has_options = True
-_QUERYROUTESREQUEST_DESTTLVENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 _QUERYROUTESREQUEST.fields_by_name['ignored_edges'].has_options = True
 _QUERYROUTESREQUEST.fields_by_name['ignored_edges']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
-_HOP_TLVRECORDSENTRY.has_options = True
-_HOP_TLVRECORDSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_EDGELOCATOR.fields_by_name['channel_id'].has_options = True
+_EDGELOCATOR.fields_by_name['channel_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
+_HOP.fields_by_name['chan_id'].has_options = True
+_HOP.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 _HOP.fields_by_name['amt_to_forward'].has_options = True
 _HOP.fields_by_name['amt_to_forward']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _HOP.fields_by_name['fee'].has_options = True
@@ -8216,18 +8328,34 @@ _ROUTE.fields_by_name['total_fees'].has_options = True
 _ROUTE.fields_by_name['total_fees']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _ROUTE.fields_by_name['total_amt'].has_options = True
 _ROUTE.fields_by_name['total_amt']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_CHANNELEDGE.fields_by_name['channel_id'].has_options = True
+_CHANNELEDGE.fields_by_name['channel_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 _CHANNELEDGE.fields_by_name['last_update'].has_options = True
 _CHANNELEDGE.fields_by_name['last_update']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_CHANINFOREQUEST.fields_by_name['chan_id'].has_options = True
+_CHANINFOREQUEST.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
+_CHANNELEDGEUPDATE.fields_by_name['chan_id'].has_options = True
+_CHANNELEDGEUPDATE.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
+_CLOSEDCHANNELUPDATE.fields_by_name['chan_id'].has_options = True
+_CLOSEDCHANNELUPDATE.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
+_HOPHINT.fields_by_name['chan_id'].has_options = True
+_HOPHINT.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 _INVOICE.fields_by_name['receipt'].has_options = True
 _INVOICE.fields_by_name['receipt']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _INVOICE.fields_by_name['settled'].has_options = True
 _INVOICE.fields_by_name['settled']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _INVOICE.fields_by_name['amt_paid'].has_options = True
 _INVOICE.fields_by_name['amt_paid']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_INVOICEHTLC.fields_by_name['chan_id'].has_options = True
+_INVOICEHTLC.fields_by_name['chan_id']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 _PAYMENT.fields_by_name['value'].has_options = True
 _PAYMENT.fields_by_name['value']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _PAYMENT.fields_by_name['fee'].has_options = True
 _PAYMENT.fields_by_name['fee']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_FORWARDINGEVENT.fields_by_name['chan_id_in'].has_options = True
+_FORWARDINGEVENT.fields_by_name['chan_id_in']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
+_FORWARDINGEVENT.fields_by_name['chan_id_out'].has_options = True
+_FORWARDINGEVENT.fields_by_name['chan_id_out']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('0\001'))
 
 _WALLETUNLOCKER = _descriptor.ServiceDescriptor(
   name='WalletUnlocker',
@@ -8235,8 +8363,8 @@ _WALLETUNLOCKER = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=20090,
-  serialized_end=20491,
+  serialized_start=20409,
+  serialized_end=20810,
   methods=[
   _descriptor.MethodDescriptor(
     name='GenSeed',
@@ -8286,8 +8414,8 @@ _LIGHTNING = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=1,
   options=None,
-  serialized_start=20494,
-  serialized_end=25462,
+  serialized_start=20813,
+  serialized_end=25879,
   methods=[
   _descriptor.MethodDescriptor(
     name='WalletBalance',
@@ -8747,6 +8875,15 @@ _LIGHTNING = _descriptor.ServiceDescriptor(
     input_type=_CHANNELBACKUPSUBSCRIPTION,
     output_type=_CHANBACKUPSNAPSHOT,
     options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='BakeMacaroon',
+    full_name='lnrpc.Lightning.BakeMacaroon',
+    index=51,
+    containing_service=None,
+    input_type=_BAKEMACAROONREQUEST,
+    output_type=_BAKEMACAROONRESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\021\"\014/v1/macaroon:\001*')),
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_LIGHTNING)

--- a/lndmanage/grpc_compiled/rpc_pb2_grpc.py
+++ b/lndmanage/grpc_compiled/rpc_pb2_grpc.py
@@ -430,6 +430,11 @@ class LightningStub(object):
         request_serializer=rpc__pb2.ChannelBackupSubscription.SerializeToString,
         response_deserializer=rpc__pb2.ChanBackupSnapshot.FromString,
         )
+    self.BakeMacaroon = channel.unary_unary(
+        '/lnrpc.Lightning/BakeMacaroon',
+        request_serializer=rpc__pb2.BakeMacaroonRequest.SerializeToString,
+        response_deserializer=rpc__pb2.BakeMacaroonResponse.FromString,
+        )
 
 
 class LightningServicer(object):
@@ -984,6 +989,16 @@ class LightningServicer(object):
     context.set_details('Method not implemented!')
     raise NotImplementedError('Method not implemented!')
 
+  def BakeMacaroon(self, request, context):
+    """* lncli: `bakemacaroon`
+    BakeMacaroon allows the creation of a new macaroon with custom read and
+    write permissions. No first-party caveats are added since this can be done
+    offline.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
 
 def add_LightningServicer_to_server(servicer, server):
   rpc_method_handlers = {
@@ -1241,6 +1256,11 @@ def add_LightningServicer_to_server(servicer, server):
           servicer.SubscribeChannelBackups,
           request_deserializer=rpc__pb2.ChannelBackupSubscription.FromString,
           response_serializer=rpc__pb2.ChanBackupSnapshot.SerializeToString,
+      ),
+      'BakeMacaroon': grpc.unary_unary_rpc_method_handler(
+          servicer.BakeMacaroon,
+          request_deserializer=rpc__pb2.BakeMacaroonRequest.FromString,
+          response_serializer=rpc__pb2.BakeMacaroonResponse.SerializeToString,
       ),
   }
   generic_handler = grpc.method_handlers_generic_handler(

--- a/lndmanage/lib/listchannels.py
+++ b/lndmanage/lib/listchannels.py
@@ -4,6 +4,7 @@ Module for printing lightning channels.
 
 import math
 import logging
+import time
 from collections import OrderedDict
 
 from lndmanage.lib.forwardings import get_forwarding_statistics_channels
@@ -223,6 +224,13 @@ PRINT_CHANNELS_FORMAT = {
         'format': '5.2f',
         'align': '>',
     },
+    'ulr': {
+        'dict_key': 'uptime_lifetime_ratio',
+        'description': 'ratio of uptime to lifetime of channel [0 ... 1]',
+        'width': 5,
+        'format': '5.2f',
+        'align': '>',
+    },
     'imed': {
         'dict_key': 'median_forwarding_in',
         'description': 'median forwarding inwards [sat]',
@@ -406,6 +414,33 @@ class ListChannels(object):
             channels,
             columns='cid,nfwd,age,fees,f/w,flow,ub,bwd,r,'
                     'cap,pbf,pfr,annotation,alias',
+            sort_dict=sort_dict)
+
+    def print_channels_hygiene(self, time_interval_start, sort_string):
+        """
+        Prints hygiene statistics for each channel.
+
+        :param time_interval_start: int
+        :param time_interval_end: int
+        :param sort_string: str
+        """
+        time_interval_end = time.time()
+        channels = get_forwarding_statistics_channels(
+            self.node, time_interval_start, time_interval_end)
+
+        channels = self._add_channel_annotations(channels)
+
+        sort_string, reverse_sorting = self._sorting_order(sort_string)
+        sort_dict = {
+            'function': lambda x:
+                x[1][sort_string],
+            'string': sort_string,
+            'reverse': reverse_sorting,
+        }
+
+        self._print_channels(
+            channels,
+            columns='cid,age,nfwd,f/w,ulr,lb,cap,pbf,pfr,annotation,alias',
             sort_dict=sort_dict)
 
     def _add_channel_annotations(self, channels):

--- a/lndmanage/lib/listchannels.py
+++ b/lndmanage/lib/listchannels.py
@@ -60,13 +60,6 @@ PRINT_CHANNELS_FORMAT = {
         'format': '5.0f',
         'align': '>',
     },
-    'bf': {
-        'dict_key': 'peer_base_fee',
-        'description': 'peer base fee [msat]',
-        'width': 5,
-        'format': '5.0f',
-        'align': '>',
-    },
     'bwd': {
         'dict_key': 'bandwidth_demand',
         'description': 'bandwidth demand: capacity / max(mean_in, mean_out)',
@@ -113,9 +106,31 @@ PRINT_CHANNELS_FORMAT = {
         # 'convert': lambda x: '>'*int(nan_to_zero(x)*10/3.0) if x > 0 else
         # '<'*(-int(nan_to_zero(x)*10/3.0))
     },
-    'fr': {
+    'pbf': {
+        'dict_key': 'peer_base_fee',
+        'description': 'peer base fee [msat]',
+        'width': 5,
+        'format': '5.0f',
+        'align': '>',
+    },
+    'pfr': {
         'dict_key': 'peer_fee_rate',
         'description': 'peer fee rate',
+        'width': 8,
+        'format': '1.6f',
+        'align': '>',
+        'convert': lambda x: x / 1E6
+    },
+    'lbf': {
+        'dict_key': 'local_base_fee',
+        'description': 'local base fee [msat]',
+        'width': 5,
+        'format': '5.0f',
+        'align': '>',
+    },
+    'lfr': {
+        'dict_key': 'local_fee_rate',
+        'description': 'local fee rate',
         'width': 8,
         'format': '1.6f',
         'align': '>',
@@ -296,8 +311,8 @@ class ListChannels(object):
         }
 
         self._print_channels(
-            channels, columns='cid,priv,act,ub,cap,lb,rb,bf,'
-                              'fr,annotation,alias',
+            channels, columns='cid,priv,act,ub,cap,lb,rb,lbf,'
+                              'lfr,annotation,alias',
             sort_dict=sort_dict)
 
     def print_channels_unbalanced(self, unbalancedness, sort_string='rev_ub'):
@@ -320,7 +335,7 @@ class ListChannels(object):
         }
 
         self._print_channels(
-            channels, columns='cid,ub,cap,lb,rb,bf,fr,annotation,alias',
+            channels, columns='cid,ub,cap,lb,rb,pbf,pfr,annotation,alias',
             sort_dict=sort_dict)
 
     def print_channels_inactive(self, sort_string='lup'):
@@ -376,7 +391,7 @@ class ListChannels(object):
         self._print_channels(
             channels,
             columns='cid,nfwd,age,fees,f/w,flow,ub,bwd,r,'
-                    'cap,bf,fr,annotation,alias',
+                    'cap,pbf,pfr,annotation,alias',
             sort_dict=sort_dict)
 
     def _add_channel_annotations(self, channels):

--- a/lndmanage/lib/listchannels.py
+++ b/lndmanage/lib/listchannels.py
@@ -378,7 +378,7 @@ class ListChannels(object):
         }
 
         self._print_channels(
-            channels, columns='cid,lupp,priv,ini,age,ub,cap,lb,rb,'
+            channels, columns='cid,lupp,ulr,priv,ini,age,ub,cap,lb,rb,'
                               'sr/w,annotation,alias',
             sort_dict=sort_dict)
 

--- a/lndmanage/lib/listchannels.py
+++ b/lndmanage/lib/listchannels.py
@@ -143,6 +143,20 @@ PRINT_CHANNELS_FORMAT = {
         'format': '5.0f',
         'align': '>',
     },
+    'lupp': {
+        'dict_key': 'last_update_peer',
+        'description': 'last update time by peer [days ago]',
+        'width': 5,
+        'format': '5.0f',
+        'align': '>',
+    },
+    'lupl': {
+        'dict_key': 'last_update_local',
+        'description': 'last update time by local [days ago]',
+        'width': 5,
+        'format': '5.0f',
+        'align': '>',
+    },
     'lb': {
         'dict_key': 'local_balance',
         'description': 'local balance [sat]',
@@ -338,7 +352,7 @@ class ListChannels(object):
             channels, columns='cid,ub,cap,lb,rb,pbf,pfr,annotation,alias',
             sort_dict=sort_dict)
 
-    def print_channels_inactive(self, sort_string='lup'):
+    def print_channels_inactive(self, sort_string='lupp'):
         """
         Prints all inactive channels.
 
@@ -356,7 +370,7 @@ class ListChannels(object):
         }
 
         self._print_channels(
-            channels, columns='cid,lup,priv,ini,age,ub,cap,lb,rb,'
+            channels, columns='cid,lupp,priv,ini,age,ub,cap,lb,rb,'
                               'sr/w,annotation,alias',
             sort_dict=sort_dict)
 

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -94,12 +94,14 @@ class Network(object):
                     'time_lock_delta': e.node1_policy.time_lock_delta,
                     'fee_base_msat': e.node1_policy.fee_base_msat,
                     'fee_rate_milli_msat': e.node1_policy.fee_rate_milli_msat,
+                    'last_update': e.node1_policy.last_update,
                     'disabled': e.node1_policy.disabled
                 },
                 'node2_policy': {
                     'time_lock_delta': e.node2_policy.time_lock_delta,
                     'fee_base_msat': e.node2_policy.fee_base_msat,
                     'fee_rate_milli_msat': e.node2_policy.fee_rate_milli_msat,
+                    'last_update': e.node2_policy.last_update,
                     'disabled': e.node2_policy.disabled
                 }}
 

--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -373,8 +373,12 @@ class LndNode(Node):
                 'total_satoshis_sent': c.total_satoshis_sent,
                 'total_satoshis_received': c.total_satoshis_received,
                 'unbalancedness': channel_unbalancedness,
+                'uptime': c.uptime,
+                'lifetime': c.lifetime,
+                'uptime_lifetime_ratio': c.uptime / c.lifetime,
             }
-        sorted_dict = OrderedDict(sorted(channels.items(), key=lambda x: x[1]['alias']))
+        sorted_dict = OrderedDict(
+            sorted(channels.items(), key=lambda x: x[1]['alias']))
         return sorted_dict
 
     def get_inactive_channels(self):

--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -320,13 +320,17 @@ class LndNode(Node):
             try:
                 edge_info = self.network.edges[c.chan_id]
                 if edge_info['node1_pub'] == self.pub_key:  # interested in node2
-                    policy = edge_info['node2_policy']
+                    policy_peer = edge_info['node2_policy']
+                    policy_local = edge_info['node1_policy']
                 else:  # interested in node1
-                    policy = edge_info['node1_policy']
+                    policy_peer = edge_info['node1_policy']
+                    policy_local = edge_info['node2_policy']
             except KeyError:
                 # TODO: if channel is unknown in describegraph we need to set the fees to some error value
-                policy = {'fee_base_msat': float(-999),
+                policy_peer = {'fee_base_msat': float(-999),
                           'fee_rate_milli_msat': float(999)}
+                policy_local = {'fee_base_msat': float(-999),
+                               'fee_rate_milli_msat': float(999)}
 
             # define unbalancedness |ub| large means very unbalanced
             channel_unbalancedness, our_commit_fee = channel_unbalancedness_and_commit_fee(
@@ -343,8 +347,10 @@ class LndNode(Node):
                 'channel_point': c.channel_point,
                 'commit_fee': c.commit_fee,
                 'fee_per_kw': c.fee_per_kw,
-                'peer_base_fee': policy['fee_base_msat'],
-                'peer_fee_rate': policy['fee_rate_milli_msat'],
+                'peer_base_fee': policy_peer['fee_base_msat'],
+                'peer_fee_rate': policy_peer['fee_rate_milli_msat'],
+                'local_base_fee': policy_local['fee_base_msat'],
+                'local_fee_rate': policy_local['fee_rate_milli_msat'],
                 'initiator': c.initiator,
                 'last_update': last_update,
                 'local_balance': c.local_balance,

--- a/lndmanage/lndmanage.py
+++ b/lndmanage/lndmanage.py
@@ -100,7 +100,7 @@ class Parser(object):
             'forwardings',
             help="displays channels with forwarding information")
         parser_listchannels_forwardings.add_argument(
-            '--from-days-ago', default=365, type=int,
+            '--from-days-ago', default=30, type=int,
             help='time interval start (days ago)')
         parser_listchannels_forwardings.add_argument(
             '--to-days-ago', default=0, type=int,
@@ -311,6 +311,9 @@ class Parser(object):
                 # convert time interval into unix timestamp
                 time_from = time.time() - args.from_days_ago * 24 * 60 * 60
                 time_to = time.time() - args.to_days_ago * 24 * 60 * 60
+                logger.info(
+                    f"Forwardings from {args.from_days_ago} days ago"
+                    f" to {args.to_days_ago} days ago are included.")
                 listchannels.print_channels_forwardings(
                     time_interval_start=time_from, time_interval_end=time_to,
                     sort_string=args.sort_by)

--- a/lndmanage/lndmanage.py
+++ b/lndmanage/lndmanage.py
@@ -93,7 +93,7 @@ class Parser(object):
         parser_listchannels_inactive = listchannels_subparsers.add_parser(
             'inactive', help="displays inactive channels")
         parser_listchannels_inactive.add_argument(
-            '--sort-by', default='lup', type=str,
+            '--sort-by', default='lupp', type=str,
             help='sort by column (look at description)')
 
         # subcmd: listchannels forwardings


### PR DESCRIPTION
This PR adds a listchannels view for information on which active channels should be closed.

It also updates the readme to be up to date with current outputs.

Furthermore it sets the default time range for `listchannels forwardings` to 30 days. This lets one focus more on the channels which were active recently.

Uptime to lifetime ratio is added to the `listchannels inactive` command.