### PR TITLE
Mission control based channel reliability score

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ age        channel age [days]
 nfwd       number of forwardings
 f/w        total fees per week [sat / week]
 ulr        ratio of uptime to lifetime of channel [0 ... 1]
+cr         channel reliability score (good routers)
+crc        channel reliability certainty (rated channels / number of channels)
+crt        total rated channels from pair history
 lb         local balance [sat]
 cap        channel capacity [sat]
 pbf        peer base fee [msat]
@@ -199,19 +202,22 @@ pfr        peer fee rate
 annotation channel annotation
 alias      alias
 -------- Channels --------
-       cid           age  nfwd    f/w   ulr        lb       cap   pbf      pfr alias           
-xxxxxxxxxxxxxxxxxx   315     0   0.00  0.20       100     91000  1000 0.000001 abc 
-xxxxxxxxxxxxxxxxxx   221     0   0.00  0.80         0    400000  1000 0.000001 def 
-xxxxxxxxxxxxxxxxxx    36     0   0.00  0.99         0    200000  1000 0.000001 ghi 
-xxxxxxxxxxxxxxxxxx    24     5   0.20  1.00    100000   4000000   500 0.000001 jkl 
-xxxxxxxxxxxxxxxxxx   117    10   1.10  1.00     30000    500000  1000 0.000001 mno
+       cid           age  nfwd    f/w   ulr    cr   crc crt      lb       cap   pbf      pfr alias           
+xxxxxxxxxxxxxxxxxx   315     0   0.00  0.20  0.00  0.00   0     100     91000  1000 0.000001 abc 
+xxxxxxxxxxxxxxxxxx   221     0   0.00  0.80  0.10  0.03  29       0    400000  1000 0.000001 def 
+xxxxxxxxxxxxxxxxxx    36     0   0.00  0.99  0.01  0.02   1       0    200000  1000 0.000001 ghi 
+xxxxxxxxxxxxxxxxxx    24     5   0.20  1.00  0.33  0.20  12  100000   4000000   500 0.000001 jkl 
+xxxxxxxxxxxxxxxxxx   117    10   1.10  1.00  0.06  0.04  15   30000    500000  1000 0.000001 mno
 ```
 You can base your decision on the number of forwardings `nfwd` and the fees
 collected per week `f/w`. If those numbers are low and the local balance `lb`
 is high and the channel already had enough time (`age`) to prove itself, you
 may want to consider closing the channel. Another way to judge the reliability
 of the channel is to look at the proportion the channel stayed active when
-your node was active, given by the `ulr` column.
+your node was active, given by the `ulr` column. An experimental feature is
+the channel reliability score `cr`. It basically tells you how our node rates
+our neighboring nodes by previous payments (rebalancings) we have carried out.
+In order to get reliable values here you need to do a lot rebalancings.
 
 ## Channel opening strategies
 Which nodes best to connect to in the Lightning Network is ongoing research. 

--- a/lndmanage/lib/listchannels.py
+++ b/lndmanage/lib/listchannels.py
@@ -8,6 +8,7 @@ import time
 from collections import OrderedDict
 
 from lndmanage.lib.forwardings import get_forwarding_statistics_channels
+from lndmanage.lib.rating import NodeRater
 from lndmanage import settings
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,28 @@ PRINT_CHANNELS_FORMAT = {
         'description': 'bandwidth demand: capacity / max(mean_in, mean_out)',
         'width': 5,
         'format': '5.2f',
+        'align': '>',
+    },
+    'cr': {
+        'dict_key': 'channel_reliability',
+        'description': 'channel reliability score (good routers)',
+        'width': 5,
+        'format': '5.2f',
+        'align': '>',
+    },
+    'crc': {
+        'dict_key': 'channel_reliability_certainty',
+        'description': 'channel reliability certainty '
+                       '(rated channels / number of channels)',
+        'width': 5,
+        'format': '5.2f',
+        'align': '>',
+    },
+    'crt': {
+        'dict_key': 'total_rated_channels',
+        'description': 'total rated channels from pair history',
+        'width': 3,
+        'format': '3.0f',
         'align': '>',
     },
     'cap': {
@@ -420,15 +443,16 @@ class ListChannels(object):
         """
         Prints hygiene statistics for each channel.
 
-        :param time_interval_start: int
-        :param time_interval_end: int
-        :param sort_string: str
+        :param time_interval_start: starting time interval for analysis (unix)
+        :type time_interval_start: int
+        :param sort_string: string for sorting (key in PRINT_CHANNELS_FORMAT)
+        :type sort_string: str
         """
         time_interval_end = time.time()
         channels = get_forwarding_statistics_channels(
             self.node, time_interval_start, time_interval_end)
-
         channels = self._add_channel_annotations(channels)
+        channels = self._add_channel_reliabilities(channels)
 
         sort_string, reverse_sorting = self._sorting_order(sort_string)
         sort_dict = {
@@ -440,7 +464,8 @@ class ListChannels(object):
 
         self._print_channels(
             channels,
-            columns='cid,age,nfwd,f/w,ulr,lb,cap,pbf,pfr,annotation,alias',
+            columns='cid,age,nfwd,f/w,ulr,cr,crc,crt,lb,cap,pbf,pfr,'
+                    'annotation,alias',
             sort_dict=sort_dict)
 
     def _add_channel_annotations(self, channels):
@@ -463,14 +488,14 @@ class ListChannels(object):
         channel_annotations_funding_id = {}
         channel_annotations_channel_id = {}
 
-        for id, annotation in annotations.items():
-            if len(id) == 18 and id.isnumeric():
+        for cid, annotation in annotations.items():
+            if len(cid) == 18 and cid.isnumeric():
                 # valid channel id
-                channel_annotations_channel_id[int(id)] = \
+                channel_annotations_channel_id[int(cid)] = \
                     annotation
-            elif len(id) == 64 and id.isalnum():
+            elif len(cid) == 64 and cid.isalnum():
                 # valid funding transaction id
-                channel_annotations_funding_id[id] = \
+                channel_annotations_funding_id[cid] = \
                     annotation
             else:
                 raise ValueError(
@@ -494,6 +519,34 @@ class ListChannels(object):
             else:
                 channels[channel_id]['annotation'] = ''
 
+        return channels
+
+    def _add_channel_reliabilities(self, channels):
+        """
+        Adds channel reliability scores to the channel data.
+
+        :param channels: channel data
+        :type channels: dict
+        :return: channel data
+        :rtype: dict
+        """
+        rater = NodeRater(self.node)
+        node_ratings = rater.rate_nodes()
+
+        for cid, channel_values in channels.items():
+            remote_pubkey = channel_values['remote_pubkey']
+            ratings = node_ratings.get(remote_pubkey, None)
+            if ratings is None:
+                channels[cid]['channel_reliability'] = 0
+                channels[cid]['channel_reliability_certainty'] = 0
+                channels[cid]['total_rated_channels'] = 0
+            else:
+                channels[cid]['channel_reliability'] = \
+                    ratings['channel_reliability']
+                channels[cid]['channel_reliability_certainty'] = \
+                    ratings['certainty']
+                channels[cid]['total_rated_channels'] = \
+                    ratings['good_channels'] + ratings['bad_channels']
         return channels
 
     def _print_channels(self, channels, columns, sort_dict):

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -139,7 +139,7 @@ class Network(object):
         :return: int
         """
         try:
-            number_of_channels = self.graph.degree[node_pub_key] / 2
+            number_of_channels = self.graph.degree[node_pub_key] // 2
         except KeyError:
             number_of_channels = 0
         return number_of_channels

--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -15,7 +15,7 @@ import lndmanage.grpc_compiled.router_pb2 as lndrouter
 import lndmanage.grpc_compiled.router_pb2_grpc as lndrouterrpc
 
 from lndmanage.lib.network import Network
-from lndmanage.lib.exceptions import PaymentTimeOut, NoRoute
+from lndmanage.lib.exceptions import PaymentTimeOut, NoRoute, RouterRPCError
 from lndmanage.lib.utilities import convert_dictionary_number_strings_to_ints
 from lndmanage.lib.ln_utilities import (
     extract_short_channel_id_from_string,
@@ -585,7 +585,35 @@ class LndNode(Node):
         logger.info(f"total satoshis received (current channels): {self.total_satoshis_received}")
         logger.info(f"total satoshis sent (current channels): {self.total_satoshis_sent}")
 
+    def query_missioncontrol(self):
+        """Queries the mission control system of lnd."""
+        try:
+            request = lndrouter.QueryMissionControlRequest()
+            result = self._routerrpc.QueryMissionControl(request)
+
+            pair_history = {}
+            for pair in result.pairs:
+                pair_history[(pair.node_from.hex(), pair.node_to.hex())] = {
+                        'timestamp': pair.history.timestamp,
+                        'min_penalize_amt_sat':
+                            pair.history.min_penalize_amt_sat,
+                        'last_attempt_successful':
+                            pair.history.last_attempt_successful,
+                }
+
+            return pair_history
+        except _Rendezvous:
+            logger.warning(
+                "Routerrpc is not available, which is neccessary to run this "
+                "command.\n"
+                "Build lnd with 'make install tags=\"routerrpc\"'.")
+            raise RouterRPCError
+
+
 
 if __name__ == '__main__':
-    node = LndNode()
+    # def __init__(self, config_file=None, lnd_home=None, lnd_host=None,
+    #             regtest=False):
+    node = LndNode(config_file='')
     print(node.get_closed_channels().keys())
+    mc = node.query_missioncontrol()

--- a/lndmanage/lib/rating.py
+++ b/lndmanage/lib/rating.py
@@ -1,4 +1,7 @@
+from collections import defaultdict, OrderedDict
+
 from lndmanage import settings
+from lndmanage.lib.exceptions import RouterRPCError
 
 import logging
 logger = logging.getLogger(__name__)
@@ -111,3 +114,140 @@ class ChannelRater(object):
             return settings.PENALTY
         else:
             return 0
+
+
+class NodeRater(object):
+    """
+    Rates nodes in the network.
+    """
+    def __init__(self, node):
+        """
+        :param node: ln node object
+        :type node: lndmanage.lib.node.LndNode
+        """
+        self.node = node
+        self.rated_nodes = defaultdict(
+            lambda: {
+                'good_channels': 0,
+                'bad_channels': 0,
+                'total_channels': None,
+                'good_fraction': 0.0,
+                'certainty': 0.0,
+            })
+
+    def rate_nodes(self):
+        """
+        Rates nodes based on mission control data.
+
+        LND records for every payment attempt the failure or success
+        of that payment on the individual parts of the route in its so-called
+        mission control. This data can be queried by the routerrpc. A channel
+        reliability score can be developped by counting how often a node
+        was involved in positive or negative scenarios.
+
+        :return: rated nodes
+        :rtype: dict
+        """
+        try:
+            pair_history = self.node.query_missioncontrol()
+
+            if len(pair_history) < 2 * self.node.num_active_channels:
+                logger.warning(
+                    f"Found less than two payment pairs per active "
+                    f"channel ({len(pair_history)} pairs found).\n"
+                    f"This usually means that the channel reliability "
+                    f"score is not accurate.\nDo some rebalancing first "
+                    f"to learn about the network.")
+            else:
+                logger.info(f"Found {len(pair_history)} payment history pairs"
+                            f" in mission control.")
+        except RouterRPCError:
+            logger.warning("Cannot calculate channel reliabilities because "
+                           "routerrpc server is not enabled.")
+            pair_history = {}
+
+        if len(pair_history) == 0:
+            return {}
+
+        # do statistics for the individual nodes
+        for node_pair, history in pair_history.items():
+            # if a payment was successful, mark nodes having a good channel
+            if history['last_attempt_successful']:
+                self.rated_nodes[node_pair[0]]['good_channels'] += 1
+                self.rated_nodes[node_pair[1]]['good_channels'] += 1
+            # if a payment was not successful, mark nodes having a bad channel
+            else:
+                self.rated_nodes[node_pair[0]]['bad_channels'] += 1
+                self.rated_nodes[node_pair[1]]['bad_channels'] += 1
+
+        # add total number of channels
+        for pubkey, stats in self.rated_nodes.items():
+            self.rated_nodes[pubkey]['total_channels'] = \
+                self.node.network.number_channels(pubkey)
+
+        discard_nodes = []
+
+        # weights for the channel reliability score:
+        # most weight is given to nodes with good ratio of good channels
+        # to bad channels
+        weight_channel_ratio = 1.0
+        # weight is given to nodes where we know we have more accurate data
+        weight_certainty = 0.5
+        # the total number of good channels indicates success for routing
+        weight_good_channels = 0.03
+
+        # construct channel reliability score
+        for pubkey, stats in self.rated_nodes.items():
+            total_rated_channels = stats['good_channels'] + stats['bad_channels']
+            try:
+                good_fraction = stats['good_channels'] / total_rated_channels
+                certainty = total_rated_channels / stats['total_channels']
+                # The reliability score consists of three components
+                # (i)   The fraction of good versus bad channels,
+                # (ii)  The certainty, which tells about how many of the node's
+                #       channels were already rated.
+                # (iii) The overall number of good channels.
+                reliability = (weight_channel_ratio * good_fraction +
+                               weight_certainty * certainty +
+                               weight_good_channels * stats['good_channels'])
+                self.rated_nodes[pubkey]['good_fraction'] = good_fraction
+                self.rated_nodes[pubkey]['certainty'] = certainty
+                self.rated_nodes[pubkey]['channel_reliability'] = reliability
+            except ZeroDivisionError:
+                discard_nodes.append(pubkey)
+
+        logger.debug(f"Discarded nodes due to missing data: f{discard_nodes}")
+        for node in discard_nodes:
+            del self.rated_nodes[node]
+
+        # sort the nodes for debugging purposes by channel reliability
+        key_values = [(k, v) for k, v in self.rated_nodes.items()]
+        sorted_key_values = sorted(
+            key_values, reverse=True,key=lambda x: x[1]['channel_reliability'])
+        ordered_nodes = OrderedDict(sorted_key_values)
+
+        # renormalize with respect to most reliable node (usually our node)
+        renormalization = max([
+            n['channel_reliability'] for n in ordered_nodes.values()])
+        for pubkey, stats in ordered_nodes.items():
+            ordered_nodes[pubkey]['channel_reliability'] /= renormalization
+
+        for pubkey, stats in ordered_nodes.items():
+            logger.debug(
+                f"{pubkey}, good chans: {stats['good_channels']}, "
+                f"bad chans: {stats['bad_channels']}, "
+                f"tot chans: {stats['total_channels']}, "
+                f"good frac: {round(stats['good_fraction'], 2)}, "
+                f"certainty: {round(stats['certainty'], 2)}, "
+                f"channel reliability: "
+                f"{round(stats['channel_reliability'], 2)}, "
+            )
+
+        return ordered_nodes
+
+
+if __name__ == '__main__':
+    from lndmanage.lib.node import LndNode
+    nd = LndNode(config_file='')
+    rd = NodeRater(nd)
+    rd.rate_nodes()


### PR DESCRIPTION
This PR adds a method to score nodes based on historic payments.

When rebalancing or sending payments somewhere, lnd is able to collect information on which parts of the payment path were succeeding or failing, which is called the payment pair history.

Using the payment pair history we can assign good and bad routing events to single nodes and calculate a channel reliability score, which uses three ingredients:

1. The fraction of good versus bad channels.
2. The certainty, which tells about how many of the node's channels were rated.
3. The overall number of good channels encounterd.

These factors are combined together with some weighting prefactors to give the channel reliability.

When rebalancing, lnd learns a lot about the peers it is connected to, as routes consist predominantly of those pees due to circular self-payments, essentially probing the peers. This is why one can use the pair history to rate the peers and decide whether they are good routers or not.

To this end, channel reliability is added to `listchannels hygiene`.