### PR TITLE
recommend nodes: second neighbors

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ Another example of the command using 'bos-scores' is
   predominantly be of outbound type, the node will have a large
  demand for inbound liquidity, which is something you want to exploit as a
  routing node.
+* ```recommend-nodes second-neighbors```: One way of positioning the node
+better in the network is to get connected to as many as possible other nodes
+with a least number of additional hops. With the `second-neighbors` command
+you can get a list of nodes that would give you the most new second neighbors,
+ if you would open up a channel with.
 
 lndmanage supports a __channel annotation functionality__. This serves for
  remembering why a certain channel was opened. By adding the funding

--- a/lndmanage/lib/network_info.py
+++ b/lndmanage/lib/network_info.py
@@ -170,28 +170,33 @@ class NetworkAnalysis(object):
         # print(len(new_second_neighbors))
         return len(new_second_neighbors)
 
-    def find_nodes_giving_most_secondary_hops(self, node_pub_key, results=10):
+    def nodes_most_second_neighbors(self, node_pub_key, number_of_nodes=10):
         """
-        Which node should be added in order to reach the most other nodes with two hops?
+        Which node should be added in order to reach the most other nodes
+        with two hops?
 
         :param node_pub_key: string
-        :param results: int
+        :param number_of_nodes: int
         :return: list of results nodes, which bring the most secondary neighbors
         """
 
         node_candidates = []
 
-        # these are the neighbors currently two hops away
-        current_close_neighbors = set(self.get_nodes_n_hops_away(node_pub_key, 2).keys())
+        # set of nodes currently two hops away
+        current_close_neighbors = set(
+            self.get_nodes_n_hops_away(node_pub_key, 2).keys())
 
+        # loop through nodes in the network and check their direct neighbors
         for n in self.node.network.graph:
-            # find neighbors of all nodes in the graph
-            potential_new_second_neighbors = set(nx.all_neighbors(self.node.network.graph, n))
-            # subtract current_close_neighbors from the potential new second neighbors
-            new_second_neighbors = potential_new_second_neighbors.difference(current_close_neighbors)
+            potential_new_second_neighbors = set(
+                nx.all_neighbors(self.node.network.graph, n))
+            # subtract current_close_neighbors from
+            # the potential new second neighbors
+            new_second_neighbors = potential_new_second_neighbors.difference(
+                current_close_neighbors)
             # add the node and its number of secondary neighbors to a list
             node_candidates.append([n, len(new_second_neighbors)])
-        return sorted(node_candidates, key=lambda x: x[1], reverse=True)[:results]
+        return sorted(node_candidates, key=lambda x: x[1], reverse=True)[:number_of_nodes]
 
     def print_find_nodes_giving_most_secondary_hops(self, node_pub_key):
         """
@@ -200,7 +205,7 @@ class NetworkAnalysis(object):
         :param node_pub_key: node public key of the interested node
         """
 
-        nodes = self.find_nodes_giving_most_secondary_hops(node_pub_key)
+        nodes = self.nodes_most_second_neighbors(node_pub_key)
         logger.info("Finding all nodes, which when connected would give n new nodes reachable with two hops.")
         for node, number_neighbors in nodes:
             logger.info(f"Node: {node} - new neighbors: {number_neighbors}")

--- a/lndmanage/lib/network_info.py
+++ b/lndmanage/lib/network_info.py
@@ -38,30 +38,40 @@ class NetworkAnalysis(object):
         # number of channels in networkx is twice the real number of channels
         nodes_and_degrees = [(n[0], n[1] // 2) for n in nodes_and_degrees]
 
-        nodes_sorted_by_degrees_decremental = sorted(nodes_and_degrees, key=lambda x: x[1], reverse=True)
+        nodes_sorted_by_degrees_decremental = sorted(
+            nodes_and_degrees, key=lambda x: x[1], reverse=True)
+
         return nodes_sorted_by_degrees_decremental[:node_count]
 
     def find_nodes_with_highest_total_capacities(self, node_count=10):
         """
-        Finds node_count nodes in the graph with the largest amount of bitcoin assigned in their channels.
+        Finds node_count nodes in the graph with the largest amount of bitcoin
+        assigned in their channels.
 
         :param node_count: int
         :return: list of nodes sorted by capacity
         """
 
         nodes_and_capacity = []
+
         for n in self.node.network.graph.nodes:
             total_capacity = 0
             edges = self.node.network.graph.edges(n, data=True)
             for e in edges:
                 total_capacity += e[2]['capacity']
             nodes_and_capacity.append((n, total_capacity))
-        nodes_and_capacity = sorted(nodes_and_capacity, key=lambda x: x[1], reverse=True)
+
+        nodes_and_capacity = sorted(
+            nodes_and_capacity, key=lambda x: x[1], reverse=True)
+
         return nodes_and_capacity[:node_count]
 
-    def get_sorted_nodes_by_property(self, key='capacity', node_count=10, decrementing=True, min_degree=0):
+    def get_sorted_nodes_by_property(self, key='capacity', node_count=10,
+                                     decrementing=True, min_degree=0):
         """
-        Returns sorted list of nodes by the key field. A minimal number of degree of the target nodes can be given.
+        Returns sorted list of nodes by the key field.
+
+        A minimal number of degree of the target nodes can be given.
 
         :param key: property by which it is sorted
         :param node_count:
@@ -74,7 +84,10 @@ class NetworkAnalysis(object):
         for node_info in self.nodes_info:
             if node_info['degree'] >= min_degree:
                 nodes.append(node_info)
-        sorted_nodes = sorted(nodes, key=lambda x: x[key], reverse=decrementing)
+
+        sorted_nodes = sorted(
+            nodes, key=lambda x: x[key], reverse=decrementing)
+
         return sorted_nodes[:node_count]
 
     def node_information(self, node_pub_key):
@@ -95,7 +108,8 @@ class NetworkAnalysis(object):
                 'capacity': total_capacity,
                 'degree': degree,
                 'capacity_per_channel': total_capacity / max(1, degree),
-                'user_nodes': self.number_of_connected_user_nodes(node_pub_key),
+                'user_nodes': self.number_of_connected_user_nodes(
+                    node_pub_key),
                 }
 
     def nodes_information(self):
@@ -112,24 +126,30 @@ class NetworkAnalysis(object):
 
     def print_node_overview(self, node_pub_key):
         """
-        Prints an overview of any node on the network. Lists the channels and their capacities/fees.
+        Prints an overview of any node on the network.
+
+        Lists the channels and their capacities/fees.
 
         :param node_pub_key:
         """
 
-        logger.info("-------- Node overview for node {} --------".format(node_pub_key))
+        logger.info("-------- Node overview for node {} --------".format(
+            node_pub_key))
         edges = list(self.node.network.graph.edges(node_pub_key, data=True))
         sorted(edges, key=lambda x: x[1])
         logger.info("Node has {} channels".format(len(edges)))
         for ie, e in enumerate(edges):
-            logger.info("Channel number: {} between {} and {}".format(ie, e[0], e[1]))
+            logger.info("Channel number: {} between {} and {}".format(
+                ie, e[0], e[1]))
             logger.info("Channel information: {}".format(e[2]))
 
     def number_of_connected_user_nodes(self, node_pub_key):
         """
-        Determines the number of 'user' nodes that a node is connected to. A user node is determined by having a
-        smaller amount of degrees than a certain value NUMBER_CHANNELS_DEFINING_USER_NODE. A node with a low number of
-        connections is assumed to be a user node.
+        Determines the number of 'user' nodes that a node is connected to.
+
+        A user node is determined by having a smaller amount of degrees than
+        a certain value NUMBER_CHANNELS_DEFINING_USER_NODE. A node with a
+        low number of connections is assumed to be a user node.
 
         :param node_pub_key: public_key of a node to be analyzed
         :return:
@@ -137,22 +157,26 @@ class NetworkAnalysis(object):
 
         connected_end_nodes = 0
         edges = self.node.network.graph.edges(node_pub_key)
+
         for e in edges:
             degree_neighbor = self.node.network.graph.degree(e[1]) // 2
             if degree_neighbor <= settings.NUMBER_CHANNELS_DEFINING_USER_NODE:
                 connected_end_nodes += 1
+
         return connected_end_nodes
 
     def get_nodes_n_hops_away(self, node_pub_key, n):
         """
-        Returns all nodes, which are n hops away from a given node_pub_key node.
+        Returns all nodes, which are n hops away from a given
+        node_pub_key node.
 
         :param node_pub_key: string
         :param n: int
         :return: dict with nodes and distance as value
         """
 
-        return nx.single_source_shortest_path_length(self.node.network.graph, node_pub_key, cutoff=n)
+        return nx.single_source_shortest_path_length(
+            self.node.network.graph, node_pub_key, cutoff=n)
 
     def secondary_hops_added(self, node_pub_key):
         """
@@ -161,13 +185,12 @@ class NetworkAnalysis(object):
         :param node_pub_key: str
         :return: int
         """
-        potential_new_second_neighbors = set(nx.all_neighbors(self.node.network.graph, node_pub_key))
-        # print('pot new', potential_new_second_neighbors)
-        current_close_neighbors = set(self.get_nodes_n_hops_away(self.node.pub_key, 2).keys())
-        # print('curr close', current_close_neighbors)
-        new_second_neighbors = potential_new_second_neighbors.difference(current_close_neighbors)
-        # print('new sec', new_second_neighbors)
-        # print(len(new_second_neighbors))
+        potential_new_second_neighbors = set(
+            nx.all_neighbors(self.node.network.graph, node_pub_key))
+        current_close_neighbors = set(
+            self.get_nodes_n_hops_away(self.node.pub_key, 2).keys())
+        new_second_neighbors = potential_new_second_neighbors.difference(
+            current_close_neighbors)
         return len(new_second_neighbors)
 
     def nodes_most_second_neighbors(self, node_pub_key, number_of_nodes=10):
@@ -177,7 +200,7 @@ class NetworkAnalysis(object):
 
         :param node_pub_key: string
         :param number_of_nodes: int
-        :return: list of results nodes, which bring the most secondary neighbors
+        :return: list of results nodes, adding the most secondary neighbors
         """
 
         node_candidates = []
@@ -190,37 +213,49 @@ class NetworkAnalysis(object):
         for n in self.node.network.graph:
             potential_new_second_neighbors = set(
                 nx.all_neighbors(self.node.network.graph, n))
+
             # subtract current_close_neighbors from
             # the potential new second neighbors
             new_second_neighbors = potential_new_second_neighbors.difference(
                 current_close_neighbors)
+
             # add the node and its number of secondary neighbors to a list
             node_candidates.append([n, len(new_second_neighbors)])
-        return sorted(node_candidates, key=lambda x: x[1], reverse=True)[:number_of_nodes]
+
+        nodes_sorted = sorted(
+            node_candidates, key=lambda x: x[1], reverse=True)
+
+        return nodes_sorted[:number_of_nodes]
 
     def print_find_nodes_giving_most_secondary_hops(self, node_pub_key):
         """
-        Determines and prints the nodes giving the most second nearest neighbors.
+        Determines and prints the nodes giving the most second
+        nearest neighbors.
 
         :param node_pub_key: node public key of the interested node
         """
 
         nodes = self.nodes_most_second_neighbors(node_pub_key)
-        logger.info("Finding all nodes, which when connected would give n new nodes reachable with two hops.")
+        logger.info("Finding all nodes, which when connected would give n new "
+                    "nodes reachable with two hops.")
+
         for node, number_neighbors in nodes:
             logger.info(f"Node: {node} - new neighbors: {number_neighbors}")
 
     def determine_channel_openings(self, from_days_ago):
         """
-        Determines all channel openings in the last `from_days_ago` days and creates a dictionary of nodes involved.
+        Determines all channel openings in the last `from_days_ago` days and
+        creates a dictionary of nodes involved.
 
-        The dictionary values contain tuples of channel creation height and capacity of the channels that were opened.
+        The dictionary values contain tuples of channel creation height and
+        capacity of the channels that were opened.
 
         :param from_days_ago: int
         :return: dict, keys: node public keys, values: (block height, capacity)
         """
 
-        logger.info(f"Determining channel openings in the last {from_days_ago} days (excluding already closed ones).")
+        logger.info(f"Determining channel openings in the last "
+                    f"{from_days_ago} days (excluding already closed ones).")
         # retrieve all channels in the network
         all_channels_list = self.node.network.edges.keys()
 
@@ -228,7 +263,8 @@ class NetworkAnalysis(object):
         all_channels_list = sorted(all_channels_list)
 
         # determine blockheight from where to start the analysis
-        blockheight_start = self.node.blockheight - from_days_ago * 24 * 6  # we have about six blocks per hour
+        # we have about six blocks per hour
+        blockheight_start = self.node.blockheight - from_days_ago * 24 * 6
 
         # take only youngest channels
         channels_filtered_and_creation_time = []
@@ -236,24 +272,30 @@ class NetworkAnalysis(object):
             height = convert_channel_id_to_short_channel_id(cid)[0]
             if height > blockheight_start:
                 channels_filtered_and_creation_time.append((cid, height))
-        logger.info(f"In the last {from_days_ago} days, there were at least {len(channels_filtered_and_creation_time)} "
+        logger.info(f"In the last {from_days_ago} days, there were at least "
+                    f"{len(channels_filtered_and_creation_time)} "
                     f"channel openings.")
 
-        # analyze the openings and assign tuples of (creation height, channel capacity) to nodes
+        # analyze the openings and assign tuples of
+        # (creation height, channel capacity) to nodes
         channel_openings_per_node_dict = defaultdict(list)
         for c, height in channels_filtered_and_creation_time:
             edge = self.node.network.edges[c]
-            channel_openings_per_node_dict[edge['node1_pub']].append((height, edge['capacity']))
-            channel_openings_per_node_dict[edge['node2_pub']].append((height, edge['capacity']))
+            channel_openings_per_node_dict[edge['node1_pub']].append(
+                (height, edge['capacity']))
+            channel_openings_per_node_dict[edge['node2_pub']].append(
+                (height, edge['capacity']))
 
         return channel_openings_per_node_dict
 
-    def calculate_channel_opening_statistics(self, from_days_ago, exclude_openings_less_than=5):
+    def calculate_channel_opening_statistics(self, from_days_ago,
+                                             exclude_openings_less_than=5):
         """
         Calculates basic channel opening statistics for each node.
 
         :param from_days_ago: int
-        :param exclude_openings_less_than: int, nodes with smaller channel openings than this are excluded
+        :param exclude_openings_less_than: int, nodes with smaller channel
+            openings than this are excluded
         :return: dict, keys: nodes, values: serveral heuristics
         """
 
@@ -265,30 +307,38 @@ class NetworkAnalysis(object):
             heights = [opening[0] for opening in nv]
             capacities = [opening[1] for opening in nv]
 
-            # calculate the blockheight differences between successive channel openings (tells about frequency)
+            # calculate the blockheight differences between successive
+            # channel openings (tells about frequency)
             delta_heights = np.diff(heights)
 
-            # calculate median and average differences of channel openings (median can give hints on bursts of openings)
+            # calculate median and average differences of channel openings
+            # (median can give hints on bursts of openings)
             median_opening_time = np.median(delta_heights)
             average_opening_time = np.mean(delta_heights)
 
             # other interesting quantities
             openings = len(capacities)
             openings_total_capacity = sum(capacities)
-            openings_average_capacity = float(openings_total_capacity) / openings
+            openings_average_capacity = \
+                float(openings_total_capacity) / openings
             node_total_capacity = self.node.network.node_capacity(n)
             node_number_channels = self.node.network.number_channels(n)
 
-            # put all the data in a dictionary, which can then be handled by the node recommendation class
+            # put all the data in a dictionary, which can then be handled
+            # by the node recommendation class
             if openings > exclude_openings_less_than:
                 opening_statistics_per_node[n] = {
                     'opening_median_time': median_opening_time,
                     'opening_average_time': average_opening_time,
-                    'openings_average_capacity': openings_average_capacity / 1E8,  # in btc
+                    'openings_average_capacity':  # unit: btc
+                        openings_average_capacity / 1E8,
                     'openings': openings,
-                    'openings_total_capacity': openings_total_capacity / 1E8,  # in btc
-                    'relative_openings': float(openings) / node_number_channels,
-                    'relative_total_capacity': float(openings_total_capacity) / node_total_capacity,  # ksat
+                    'openings_total_capacity':  # unit: btc
+                        openings_total_capacity / 1E8,
+                    'relative_openings':
+                        float(openings) / node_number_channels,
+                    'relative_total_capacity':  # unit: ksat
+                        float(openings_total_capacity) / node_total_capacity,
                 }
 
         return opening_statistics_per_node
@@ -301,7 +351,8 @@ class NetworkAnalysis(object):
         :return: int
         """
         try:
-            distance = nx.shortest_path_length(self.node.network.graph, source=first_node, target=second_node)
+            distance = nx.shortest_path_length(
+                self.node.network.graph, source=first_node, target=second_node)
         except nx.exception.NetworkXNoPath:
             distance = float('inf')  # some high number
 

--- a/lndmanage/lib/recommend_nodes.py
+++ b/lndmanage/lib/recommend_nodes.py
@@ -152,6 +152,13 @@ print_node_format = {
         'format': '9d',
         'align': '>',
     },
+    'sec': {
+        'dict_key': 'new_second_neighbors',
+        'description': 'new second neighbors',
+        'width': 5,
+        'format': '5d',
+        'align': '>',
+    },
     'weight': {
         'dict_key': 'weight',
         'description': 'forwarding weight',
@@ -168,8 +175,6 @@ class RecommendNodes(object):
     """
     def __init__(self, node, show_connected=False, show_addresses=False):
         self.node = node
-        self.network_analysis = NetworkAnalysis(self.node)
-
         self.show_connected = show_connected
         self.show_address = show_addresses
         self.network_analysis = NetworkAnalysis(self.node)
@@ -204,6 +209,12 @@ class RecommendNodes(object):
                         'openmed,openavg,nchan,cap,cpc,age,alias'
         self.print_nodes(
             nodes, number_of_nodes, format_string, sort_by=sort_by)
+
+    def print_second_neighbors(self, number_of_nodes=20, sort_by='sec'):
+        nodes = self.second_neighbors(number_of_nodes)
+        nodes = self.add_metadata_and_remove_pruned(nodes)
+        format_string = 'rpk,sec,nchan,cap,cpc,alias'
+        self.print_nodes(nodes, number_of_nodes, format_string, sort_by)
 
     def good_old(self):
         """
@@ -366,6 +377,24 @@ class RecommendNodes(object):
             # node operators who dedicate themselves to their nodes and add
             # a lot of value to the network
             nodes[n]['metric_steady'] = nv['opening_median_time'] * (nv['openings_total_capacity'])**2
+
+        return nodes
+
+    def second_neighbors(self, number_of_nodes):
+        """
+        Returns a dict of nodes, which would give the most second neighbors
+        when would be opened to them.
+
+        :param number_of_nodes: number of nodes returned
+        :type number_of_nodes: int
+        :return: nodes
+        :rtype: dict
+        """
+        node_tuples = self.network_analysis.nodes_most_second_neighbors(
+            self.node.pub_key, number_of_nodes)
+        nodes = {}
+        for n in node_tuples:
+            nodes[n[0]] = {'new_second_neighbors': n[1]}
 
         return nodes
 

--- a/lndmanage/lndmanage.py
+++ b/lndmanage/lndmanage.py
@@ -206,8 +206,7 @@ class Parser(object):
         parser_recommend_nodes_good_old = \
             parser_recommend_nodes_subparsers.add_parser(
                 'good-old',
-                help='shows nodes already interacted with but no '
-                     'active channels',
+                help='nodes with previous good relationship (channels)',
                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         parser_recommend_nodes_good_old.add_argument(
             '--nnodes', default=20, type=int,
@@ -219,7 +218,7 @@ class Parser(object):
         # subcmd: recommend-nodes flow-analysis
         parser_recommend_nodes_flow_analysis = \
             parser_recommend_nodes_subparsers.add_parser(
-                'flow-analysis', help='recommends nodes from a flow analysis',
+                'flow-analysis', help='nodes from a flow analysis',
                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         parser_recommend_nodes_flow_analysis.add_argument(
             '--nnodes', default=20, type=int,
@@ -239,7 +238,7 @@ class Parser(object):
         parser_recommend_nodes_external_source = \
             parser_recommend_nodes_subparsers.add_parser(
                 'external-source',
-                help='recommends nodes from a given file/url',
+                help='nodes from a given file/url',
                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         parser_recommend_nodes_external_source.add_argument(
             '--nnodes', default=20, type=int,
@@ -261,7 +260,7 @@ class Parser(object):
         parser_recommend_nodes_channel_openings = \
             parser_recommend_nodes_subparsers.add_parser(
                 'channel-openings',
-                help='recommends nodes from recent channel openings',
+                help='nodes from recent channel openings',
                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         parser_recommend_nodes_channel_openings.add_argument(
             '--nnodes', default=20, type=int,
@@ -273,6 +272,28 @@ class Parser(object):
         parser_recommend_nodes_channel_openings.add_argument(
             '--sort-by', default='msteady', type=str,
             help="sort by column [abbreviation, e.g. 'nchan']")
+
+        # subcmd: recommend-nodes second-neighbors
+        parser_recommend_nodes_second_neighbors = \
+            parser_recommend_nodes_subparsers.add_parser(
+                'second-neighbors',
+                help='nodes from network analysis giving most '
+                     'second neighbors',
+                description="This command recommends nodes for getting more "
+                            "second neighbors. "
+                            "This is achieved by checking how many second "
+                            "neighbors would be added if one would connect to "
+                            "the suggested node. A channel to the node "
+                            "should get your node closer to "
+                            "more other nodes.",
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser_recommend_nodes_second_neighbors.add_argument(
+            '--nnodes', default=20, type=int,
+            help='sets the number of nodes displayed')
+        parser_recommend_nodes_second_neighbors.add_argument(
+            '--sort-by', default='sec', type=str,
+            help="sort by column [abbreviation, e.g. 'sec']")
+
 
         # cmd: report
         parser_report = subparsers.add_parser(
@@ -389,6 +410,9 @@ class Parser(object):
             elif args.subcmd == 'channel-openings':
                 recommend_nodes.print_channel_openings(
                     from_days_ago=args.from_days_ago,
+                    number_of_nodes=args.nnodes, sort_by=args.sort_by)
+            elif args.subcmd == 'second-neighbors':
+                recommend_nodes.print_second_neighbors(
                     number_of_nodes=args.nnodes, sort_by=args.sort_by)
 
         elif args.cmd == 'report':


### PR DESCRIPTION
This PR adds node recommendation for more second neighbors.
This is achieved by checking how many second neighbors would be added
if one would connect to another node. This should get oneselve's node
closer to not so well connected nodes and therefore position one's node
better to route more transactions.