### PR TITLE
test+node: create integration test for node with no channels, fix bug

### DIFF
--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -327,7 +327,12 @@ class LndNode(Node):
         """
         raw_channels = self._rpc.ListChannels(lnd.ListChannelsRequest(
             active_only=active_only, public_only=public_only))
-        channels_data = raw_channels.ListFields()[0][1]
+        try:
+            channels_data = raw_channels.ListFields()[0][1]
+        except IndexError:
+            # If there are no channels, return.
+            return OrderedDict({})
+
         channels = OrderedDict()
 
         for c in channels_data:

--- a/test/graph_definitions/empty_graph.py
+++ b/test/graph_definitions/empty_graph.py
@@ -1,0 +1,15 @@
+"""
+Implements a lightning network topology with only one node and no channels.
+"""
+nodes = {
+    'A': {
+        'grpc_port': 11009,
+        'rest_port': 8080,
+        'port': 9735,
+        'base_fee_msat': 1,
+        'fee_rate': 0.000001,
+        'channels': {
+        }
+    },
+}
+

--- a/test/test_itest.py
+++ b/test/test_itest.py
@@ -1,0 +1,22 @@
+"""
+Integration tests for lndmanage.
+"""
+from test.testnetwork import TestNetwork
+from test.testing_common import test_graphs_paths
+
+
+class NewNode(TestNetwork):
+    """
+    NewNode tests behavior of lndmanage under a blank new node without any
+    channels.
+    """
+    network_definition = test_graphs_paths['empty_graph']
+
+    def graph_test(self):
+        self.assertEqual(1, self.master_node_networkinfo['num_nodes'])
+        self.assertEqual(0, self.master_node_networkinfo['num_channels'])
+
+    def test_empty(self):
+        # LND interface of lndmanage is initialized in setUp method of super
+        # class, so nothing is needed here.
+        pass

--- a/test/testing_common.py
+++ b/test/testing_common.py
@@ -24,5 +24,7 @@ test_graphs_paths = {
         graph_definitions_dir, 'star_ring_4_unbalanced.py'),
     'star_ring_4_illiquid': os.path.join(
         graph_definitions_dir, 'star_ring_4_illiquid.py'),
+    'empty_graph': os.path.join(
+        graph_definitions_dir, 'empty_graph.py'),
 }
 

--- a/test/testnetwork.py
+++ b/test/testnetwork.py
@@ -1,0 +1,75 @@
+"""
+Defines a general live test network class for integration testing.
+"""
+from unittest import TestCase
+
+from lnregtest.lib.network import RegtestNetwork
+
+from lndmanage.lib.node import LndNode
+
+from test.testing_common import (
+    bin_dir,
+    test_data_dir,
+)
+
+import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class TestNetwork(TestCase):
+    """
+    Class for spinning up simulated Lightning Networks to do integration
+    testing.
+
+    The implementation inheriting from this class needs to implement the
+    graph_test method, which tests properties specific to the chosen test
+    network graph. The attribute network_definition is a string that points
+    to the file location of a network graph definition in terms of a dict.
+    """
+    network_definition = None
+
+    def setUp(self):
+        if self.network_definition is None:
+            self.skipTest("This class doesn't represent a real test case.")
+            raise NotImplementedError("A network definition path needs to be "
+                                      "given.")
+
+        self.testnet = RegtestNetwork(
+            binary_folder=bin_dir,
+            network_definition_location=self.network_definition,
+            nodedata_folder=test_data_dir,
+            node_limit='H',
+            from_scratch=True
+        )
+        self.testnet.run_nocleanup()
+        # to run the lightning network in the background and do some testing
+        # here, run:
+        # $ lnregtest --nodedata_folder /path/to/lndmanage/test/test_data/
+        # self.testnet.run_from_background()
+
+        # logger.info("Generated network information:")
+        # logger.info(format_dict(self.testnet.node_mapping))
+        # logger.info(format_dict(self.testnet.channel_mapping))
+        # logger.info(format_dict(self.testnet.assemble_graph()))
+
+        master_node_data_dir = self.testnet.master_node.lnd_data_dir
+        master_node_port = self.testnet.master_node.grpc_port
+        self.master_node_networkinfo = self.testnet.master_node.getnetworkinfo()
+
+        self.lndnode = LndNode(
+            lnd_home=master_node_data_dir,
+            lnd_host='localhost:' + str(master_node_port),
+            regtest=True
+        )
+        self.graph_test()
+
+    def tearDown(self):
+        self.testnet.cleanup()
+
+    def graph_test(self):
+        """
+        graph_test should be implemented by each subclass test and check,
+        whether the test graph has the correct shape.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
Creates a new super class for integration testing of live lightning networks and updates existing tests to use that. A new test graph is added, where only the master node is existent. This is then used to simulate a node where no channels have been opened yet. Fixes #67, where an exception is raised when no channels are present .