### PR TITLE
lncli support in interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Current feature list (use the ```--help``` flag for subcommands):
   * a target 'balancedness' can be specified (e.g. to empty the channel)
 * __Circular self-payments ```circle```__
 * __Recommendation of good nodes ```recommend-nodes```__
+* __Support of lncli__
    
 **DISCLAIMER: This is BETA software, so please be careful (All actions are 
   executed as a dry run unless you call lndmanage with the ```--reckless``` 
@@ -314,6 +315,23 @@ transaction id or channel id to the config file `~/.lndmanage/config.ini`
 under the `annotations` section (as specified in 
 [`config_sample.ini`](lndmanage/templates/config_sample.ini)), annotations
 can be saved. These annotations will then appear in the `listchannels` views.
+
+## Support of lncli
+lndmanage supports the native command line interface of `lnd` in interactive mode.
+This achieves the goal of having to only open one terminal window for node
+management and enables an easy way to run `lncli` from remote machines. In
+interactive mode `lncli` is available as it would be via command line, e.g.:
+
+`$ lndmangage lncli getinfo`
+
+The json text output you get from `lncli` is syntax highlighted. To enable
+`lncli` support, lndmanage needs to find the `lncli` executable on the path, or
+in the `~/.lndmanage` home folder (or environment variable `LNDMANAGE_HOME`).
+To get the `lncli` binary, copy it over from your `$GOPATH/bin/lncli`, compile it
+yourself, or download one of the official [releases](https://github.com/lightningnetwork/lnd/releases).
+*If lndmanage runs on the same host as `lnd` you typically don't have to do
+anything.* To check if it's working you should see
+`Enabled lncli: using /path/to/lncli` and be able to access the `lncli` option.
 
 ## Setup
 lndmanage will be developed in lockstep with lnd and tagged accordingly. 

--- a/lndmanage/lib/lncli.py
+++ b/lndmanage/lib/lncli.py
@@ -1,0 +1,68 @@
+"""
+Handling lncli interaction.
+"""
+import os
+import subprocess
+import json
+
+from pygments import highlight, lexers, formatters
+from lndmanage import settings
+
+import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class Lncli(object):
+    def __init__(self, lncli_path, config_file):
+        self.lncli_path = lncli_path
+
+        config = settings.read_config(config_file)
+
+        cert_file = os.path.expanduser(config['network']['tls_cert_file'])
+        macaroon_file = \
+            os.path.expanduser(config['network']['admin_macaroon_file'])
+        lnd_host = config['network']['lnd_grpc_host']
+
+        # assemble the command for lncli for execution with flags
+        self.lncli_command = [
+            self.lncli_path,
+            '--rpcserver=' + lnd_host,
+            '--macaroonpath=' + macaroon_file,
+            '--tlscertpath=' + cert_file
+            ]
+
+    def lncli(self, command):
+        """
+        Invokes the lncli command line interface for lnd.
+
+        :param command: list of command line arguments
+        :return:
+            int: error code
+        """
+
+        cmd = self.lncli_command + command
+        logger.debug('executing lncli %s', ' '.join(cmd))
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # check if the output can be decoded from valid json
+        try:
+            json.loads(proc.stdout)
+            # convert json into color coded characters
+            colorful_json = highlight(
+                proc.stdout,
+                lexers.JsonLexer(),
+                formatters.TerminalFormatter()
+            )
+            logger.info(colorful_json)
+
+        # usually errors and help are not json, handle them here
+        except ValueError:
+            logger.info(proc.stdout.decode('utf-8'))
+            logger.info(proc.stderr.decode('utf-8'))
+
+        return proc.returncode

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ protobuf==3.7.1
 pyparsing==2.4.0
 python-dateutil==2.8.0
 six==1.12.0
+Pygments==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         'networkx==2.2',
         'numpy==1.16.2',
         'protobuf==3.7.1',
+        'Pygments==2.4.2',
         'pyparsing==2.4.0',
         'python-dateutil==2.8.0',
         'six==1.12.0',


### PR DESCRIPTION
With this PR, lndmanage supports the native command line interface of `lnd` in interactive mode. This achieves the goal of having to only open one terminal window for node management and enables an easy way to run `lncli` from remote machines. In interactive mode `lncli` is available as it would be via command line, e.g.:

`$ lndmangage lncli getinfo`

The json text output one gets from `lncli` is syntax highlighted.

To enable `lncli` support, lndmanage needs to find the `lncli` executable on the path, or in the `~/.lndmanage` home folder (or in the environment variable `LNDMANAGE_HOME`).