### PR TITLE
node: fix zero division for zero capacity

### DIFF
--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -651,8 +651,12 @@ class LndNode(Node):
 
     def print_status(self):
         logger.info("-------- Node status --------")
-        balancedness_local = self.total_local_balance / self.total_capacity
-        balancedness_remote = self.total_remote_balance / self.total_capacity
+        if self.total_capacity == 0:
+            balancedness_local = 0
+            balancedness_remote = 0
+        else:
+            balancedness_local = self.total_local_balance / self.total_capacity
+            balancedness_remote = self.total_remote_balance / self.total_capacity
         logger.info(f"alias: {self.alias}")
         logger.info(f"pub key: {self.pub_key}")
         logger.info(f"blockheight: {self.blockheight}")


### PR DESCRIPTION
for method lndmanage status:
bug: in the case where total_capacity = 0, throws ZeroDivisionError.
fix: return 0 for balancedness_local and balancedness_remote in the case where total_capacity = 0