### PR TITLE
NetworkX 2.4 compatibility: node -> nodes

### DIFF
--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -165,7 +165,7 @@ class Network(object):
         :return: alias string
         """
         try:
-            return self.graph.node[node_pub_key]['alias']
+            return self.graph.nodes[node_pub_key]['alias']
         except KeyError:
             return 'unknown alias'
 
@@ -176,7 +176,7 @@ class Network(object):
         :param node_pub_key:
         :return: list
         """
-        return self.graph.node[node_pub_key]['address']
+        return self.graph.nodes[node_pub_key]['address']
 
     def node_age(self, node_pub_key):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ googleapis-common-protos==1.5.9
 grpcio==1.19.0
 grpcio-tools==1.13.0
 kiwisolver==1.0.1
-networkx==2.2
+networkx==2.4
 numpy==1.16.2
 protobuf==3.7.1
 pyparsing==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         'grpcio==1.19.0',
         'grpcio-tools==1.13.0',
         'kiwisolver==1.0.1',
-        'networkx==2.2',
+        'networkx==2.4',
         'numpy==1.16.2',
         'protobuf==3.7.1',
         'Pygments==2.4.2',


### PR DESCRIPTION
G.node was removed in 2.4: https://networkx.github.io/documentation/latest/release/release_2.4.html

Other parts of lndmanage refer to G.nodes so it should probably work with 2.2 as well.

```
$ lndmanage status
Initializing node interface.
Initializing network graph.
Saved graph is too old. Fetching new one.
Traceback (most recent call last):
  File "/nix/store/q8il8a40aqrdhh6ncpvn9f9fwgmy6hc3-lndmanage-0.10.0/bin/.lndmanage-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/q8il8a40aqrdhh6ncpvn9f9fwgmy6hc3-lndmanage-0.10.0/lib/python3.7/site-packages/lndmanage/lndmanage.py", line 479, in main
    node = LndNode(config_file=config_file)
  File "/nix/store/q8il8a40aqrdhh6ncpvn9f9fwgmy6hc3-lndmanage-0.10.0/lib/python3.7/site-packages/lndmanage/lib/node.py", line 85, in __init__
    self.set_info()
  File "/nix/store/q8il8a40aqrdhh6ncpvn9f9fwgmy6hc3-lndmanage-0.10.0/lib/python3.7/site-packages/lndmanage/lib/node.py", line 297, in set_info
    active_only=False, public_only=False)
  File "/nix/store/q8il8a40aqrdhh6ncpvn9f9fwgmy6hc3-lndmanage-0.10.0/lib/python3.7/site-packages/lndmanage/lib/node.py", line 396, in get_open_channels
    'alias': self.network.node_alias(c.remote_pubkey),
  File "/nix/store/q8il8a40aqrdhh6ncpvn9f9fwgmy6hc3-lndmanage-0.10.0/lib/python3.7/site-packages/lndmanage/lib/network.py", line 168, in node_alias
    return self.graph.node[node_pub_key]['alias']
AttributeError: 'MultiDiGraph' object has no attribute 'node'
```