### PR TITLE
Install python-wheel in docker build container

### DIFF
--- a/docker/lndmanage/Dockerfile
+++ b/docker/lndmanage/Dockerfile
@@ -11,7 +11,7 @@ ARG LNDMANAGE_HOST_SRC_PATH
 
 COPY "$LNDMANAGE_HOST_SRC_PATH/requirements.txt" .
 
-RUN pip install -r requirements.txt
+RUN pip install wheel && pip install -r requirements.txt
 
 # ---------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves the following when trying to build docker container via build.sh:

```
Status: Downloaded newer image for python:3
 ---> 619f31abac4b
Step 2/20 : RUN python -m venv /root/.venv
 ---> Running in 3b7ed423aff3
Removing intermediate container 3b7ed423aff3
 ---> 9ab5279b1385
Step 3/20 : ENV PATH="/root/.venv/bin:$PATH"
 ---> Running in d26569851a5e
Removing intermediate container d26569851a5e
 ---> ae8ae629854d
Step 4/20 : ARG LNDMANAGE_HOST_SRC_PATH
 ---> Running in 12f9b49f4b73
Removing intermediate container 12f9b49f4b73
 ---> 5053e156e6a8
Step 5/20 : COPY "$LNDMANAGE_HOST_SRC_PATH/requirements.txt" .
 ---> dfe7810fc80f
Step 6/20 : RUN pip install -r requirements.txt
 ---> Running in 361965a078d0
Collecting cycler==0.10.0
  Downloading cycler-0.10.0-py2.py3-none-any.whl (6.5 kB)
Collecting decorator==4.4.2
  Downloading decorator-4.4.2-py2.py3-none-any.whl (9.2 kB)
Collecting googleapis-common-protos==1.52.0
  Downloading googleapis_common_protos-1.52.0-py2.py3-none-any.whl (100 kB)
Collecting grpcio==1.31.0
  Downloading grpcio-1.31.0.tar.gz (20.0 MB)
Collecting grpcio-tools==1.31.0
  Downloading grpcio-tools-1.31.0.tar.gz (2.1 MB)
Collecting kiwisolver==1.2.0
  Downloading kiwisolver-1.2.0.tar.gz (52 kB)
    ERROR: Command errored out with exit status 1:
     command: /root/.venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-u8e7rr0b/kiwisolver/setup.py'"'"'; __file__='"'"'/tmp/pip-install-u8e7rr0b/kiwisolver/setup.py'"'"';f=
getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-s0mfbq0l
         cwd: /tmp/pip-install-u8e7rr0b/kiwisolver/
    Complete output (44 lines):
    WARNING: The wheel package is not available.
      ERROR: Command errored out with exit status 1:
       command: /root/.venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-wheel-g9n0182y/cppy/setup.py'"'"'; __file__='"'"'/tmp/pip-wheel-g9n0182y/cppy/setup.py'"'"';f=getattr(tok
enize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-j1hnjzgk
           cwd: /tmp/pip-wheel-g9n0182y/cppy/
      Complete output (6 lines):
      usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
         or: setup.py --help [cmd1 cmd2 ...]
         or: setup.py --help-commands
         or: setup.py cmd --help

      error: invalid command 'bdist_wheel'
      ----------------------------------------
      ERROR: Failed building wheel for cppy
    ERROR: Failed to build one or more wheels
    Traceback (most recent call last):
      File "/root/.venv/lib/python3.9/site-packages/setuptools/installer.py", line 128, in fetch_build_egg
        subprocess.check_call(cmd)
      File "/usr/local/lib/python3.9/subprocess.py", line 373, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['/root/.venv/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmp7am86r8u', '--quiet', 'cppy>=1.1.0']' returned non-zero exit
status 1.

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-u8e7rr0b/kiwisolver/setup.py", line 59, in <module>
        setup(
      File "/root/.venv/lib/python3.9/site-packages/setuptools/__init__.py", line 164, in setup
        _install_setup_requires(attrs)
      File "/root/.venv/lib/python3.9/site-packages/setuptools/__init__.py", line 159, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/root/.venv/lib/python3.9/site-packages/setuptools/dist.py", line 699, in fetch_build_eggs
        resolved_dists = pkg_resources.working_set.resolve(
      File "/root/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 779, in resolve
        dist = best[req.key] = env.best_match(
      File "/root/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1064, in best_match
        return self.obtain(req, installer)
      File "/root/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1076, in obtain
        return installer(requirement)
      File "/root/.venv/lib/python3.9/site-packages/setuptools/dist.py", line 758, in fetch_build_egg
        return fetch_build_egg(self, req)
      File "/root/.venv/lib/python3.9/site-packages/setuptools/installer.py", line 130, in fetch_build_egg
        raise DistutilsError(str(e)) from e
    distutils.errors.DistutilsError: Command '['/root/.venv/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmp7am86r8u', '--quiet', 'cppy>=1.1.0']' returned non-zero exi
t status 1.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
WARNING: You are using pip version 20.2.3; however, version 21.0.1 is available.
You should consider upgrading via the '/root/.venv/bin/python -m pip install --upgrade pip' command.

```