### PR TITLE
Openchannels: new command for batched/coin-controlled channel opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,21 @@ lndmanage is a command line tool for advanced channel management of an
 
 Current feature list (use the ```--help``` flag for subcommands):
 
-* __Activity reports ```report```__
-* __Display the node summary ```status```__
-* __Info command ```info```__: display info about a channel or node
-* __Advanced channel listings ```listchannels```__
+* Activity reports ```report```
+* Display the node summary ```status```
+* ```info``` command: explore info about a channel or node in the graph
+* Advanced channel listings ```listchannels```
   * ```listchannels rebalance```: list channels for rebalancing
   * ```listchannels forwardings```: list forwarding statistics for each channel 
   * ```listchannels hygiene```: information for closing of active channels
   * ```listchannels inactive```: information on inactive channels
-* __Rebalancing command ```rebalance```__
+* Rebalancing command ```rebalance```
   * different rebalancing strategies can be chosen
   * a target 'balancedness' can be specified (e.g. to empty the channel)
-* __Circular self-payments ```circle```__
-* __Recommendation of good nodes ```recommend-nodes```__
-* __Support of lncli__
+* Circular self-payments ```circle```
+* Recommendation of good nodes ```recommend-nodes```
+* Batched channel opening ```openchannels```
+* Support of ```lncli```
    
 **DISCLAIMER: This is BETA software, so please be careful (All actions are 
   executed as a dry run unless you call lndmanage with the ```--reckless``` 
@@ -37,14 +38,16 @@ Lightning network daemon channel management tool.
 
 positional arguments:
   {status,listchannels,rebalance,circle}
-    circle              circular self-payment
+    status              display node status
     listchannels        lists channels with extended information [see also
                         subcommands with -h]
     rebalance           rebalance a channel
+    circle              circular self-payment
     recommend-nodes     recommends nodes [see also subcommands with -h]
     report              displays reports of activity on the node
-    status              display node status
     info                displays info on channels and nodes
+    lncli               execute lncli
+    openchannels        opens multiple channels with UTXO control
 ```
 
 ## Info Command
@@ -315,6 +318,26 @@ transaction id or channel id to the config file `~/.lndmanage/config.ini`
 under the `annotations` section (as specified in 
 [`config_sample.ini`](lndmanage/templates/config_sample.ini)), annotations
 can be saved. These annotations will then appear in the `listchannels` views.
+
+## Batched channel opening
+lndmanage supports batched channel opening support using LND's internal wallet.
+With this command you can specify node pubkeys, amounts, and have coin control
+to avoid change creation. Reserves for anchor commitments are respected or
+created automatically.
+
+The `openchannels` command can operate in several ways. You only specify 
+the node pubkeys as a minimal input and the tool will automatically connect
+to the nodes in the channel opening process. You may also specify a list
+of UTXOs which are used as the budget. The individual channel capacities
+can be given either as absolute values, or as relative values 
+(they will be rescaled to the sum of UTXOs), or you can give a total amount,
+which will be distributed over the new channels.
+
+Anchor commitments introduce some UX issues with reserving UTXOs that are needed
+to confirm commitment transactions in time via child-pays-for-parent. This is 
+why you won't be able to spend down all funds on newer versions of LND.
+lndmanage recognizes this case and will not touch small UTXOs that are suitable
+for reserves, or it will create them.
 
 ## Support of lncli
 lndmanage supports the native command line interface of `lnd` in interactive mode.

--- a/lndmanage/lib/openchannels.py
+++ b/lndmanage/lib/openchannels.py
@@ -1,0 +1,378 @@
+"""
+Module for opening lightning channels in a batched way.
+"""
+from math import ceil
+import logging
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from lndmanage.lib.types import UTXO, AddressType
+from lndmanage import settings
+
+if TYPE_CHECKING:
+    from lndmanage.lib.node import LndNode
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+# transaction component sizes
+# parameters via github.com/virtu/libtxsize
+# ./libtxsize-cli.py -i P2SH-P2WPKH,P2WPKH -o P2WSH-2-of-2-MULTISIG,P2WPKH
+
+# version, locktime, nins, nouts
+TRANSACTION_OVERHEAD_VBYTES = 8 + 1 + 1
+# inputs
+P2WPKH_INPUT_VBYTES = 41
+P2SH_P2WPKH_INPUT_VBYTES = 64
+# outputs
+P2WSH_OUTPUT_VBYTES = 43
+P2WPKH_OUTPUT_VBYTES = 31
+# witness
+P2SH_P2WPKH_INPUT_WITNESS_WEIGHT = 109
+P2WPKH_INPUT_WITNESS_WEIGHT = 109
+MARKER_FLAG_WEIGHT = 2
+WITNESS_NUM_INPUT_WEIGHT = 1
+WITNESS_SCALE = 4
+
+ANCHOR_RESERVE = 10 * 10000
+MAX_ANCHOR_RESERVE = 5 * ANCHOR_RESERVE
+MIN_CHANNEL_SIZE = 500000
+WUMBO_LIMIT = 16777215
+
+def calculate_fees(sat_per_vbyte: int, num_p2wkh_inputs: int, num_np2wkh_inputs,
+                   num_channels: int, has_change=False) -> int:
+    """Calculates the size (in vbytes) of a transaction and determines the fee."""
+    # see also https://github.com/btcsuite/btcwallet/tree/master/wallet/txsizes/size.go
+    # for lnd fee calculation
+    size_vbytes = 0
+    size_vbytes += TRANSACTION_OVERHEAD_VBYTES
+    size_vbytes += P2WPKH_INPUT_VBYTES * num_p2wkh_inputs
+    size_vbytes += P2SH_P2WPKH_INPUT_VBYTES * num_np2wkh_inputs
+    size_vbytes += P2WSH_OUTPUT_VBYTES * num_channels
+
+    # due to a bug in lnd fee estimation, we always add a change output here
+    size_vbytes += P2WPKH_OUTPUT_VBYTES
+
+    if has_change:
+        size_vbytes += P2WPKH_OUTPUT_VBYTES
+
+    # add witness data
+    witness_weight = 0
+    witness_weight += MARKER_FLAG_WEIGHT
+    witness_weight += WITNESS_NUM_INPUT_WEIGHT
+    witness_weight += P2WPKH_INPUT_WITNESS_WEIGHT * num_p2wkh_inputs
+    witness_weight += P2SH_P2WPKH_INPUT_WITNESS_WEIGHT * num_np2wkh_inputs
+
+    # for the total vbytes, discount witness data
+    size_vbytes = size_vbytes + (witness_weight + 3) / WITNESS_SCALE
+
+    logger.debug(
+        f"    Transaction size calculation for "
+        f"{num_p2wkh_inputs} (p2wkh) + {num_np2wkh_inputs} (np2wkh) inputs, {num_channels}"
+        f"channels, change {has_change}: {int(size_vbytes)} vbytes"
+    )
+    # take an overestimation, let LND reduce fees (as LND's fee estimation is buggy)
+    return int(size_vbytes * sat_per_vbyte)
+
+
+def count_input_types(utxos: List[UTXO]) -> Tuple[int, int]:
+    """Count the number of p2wkh and np2wkh inputs in the list of UTXOs."""
+    num_p2wkh = 0
+    num_npw2kh = 0
+    for utxo in utxos:
+        if utxo.transaction_type == AddressType.WITNESS_PUBKEY_HASH:
+            num_p2wkh += 1
+        elif utxo.transaction_type == AddressType.NESTED_PUBKEY_HASH:
+            num_npw2kh += 1
+    return num_p2wkh, num_npw2kh
+
+
+def provide_coins(utxos: List[UTXO], total_amount_requested: Optional[int],
+                  spend_all_utxos: bool, sat_per_vbyte: int, num_channels: int,
+                  anchor_reserve: int) -> Tuple[List[UTXO], int, int, int]:
+    """Selects coins from a list of UTXOs to spend a total amount.
+
+    A total amount of None indicates that we want to spend all uxtos.
+
+    If spend_all_utxos is true, all utxos will be included as the inputs, and
+    change is accordingly created.
+    The coin selection handles the reservation of anchor funds.
+
+    :returns
+    included UTXOS,
+    total budget spendable in sat,
+    change amount in sat,
+    fee amount in sat
+    """
+    available_utxos = sorted(utxos, reverse=True)  # decreasing order
+
+    if not total_amount_requested:  # try to spend the full UTXO set
+        create_anchor_output = bool(anchor_reserve)
+        # Here we try to spend all funds. If we should reserve some funds for
+        # anchor outputs, we try to take some already existent small UTXOs. If
+        # that's not possible, we need to create a change output.
+        anchor_utxos = []
+        if create_anchor_output:
+            # Search for viable anchor UTXOs beginning from the smallest UTXO.
+            for utxo in reversed(available_utxos):
+                anchor_utxos.append(utxo)
+                if anchor_reserve <= sum(utxo.amount_sat for utxo in anchor_utxos) <= MAX_ANCHOR_RESERVE:
+                    logger.info("    Reserving UTXOs for anchors:")
+                    for anchor_utxo in anchor_utxos:
+                        logger.info(f"    {str(anchor_utxo)}")
+                        available_utxos.remove(anchor_utxo)
+                    create_anchor_output = False
+                    break
+        num_p2wkh, num_np2wkh = count_input_types(available_utxos)
+        fee = calculate_fees(
+            sat_per_vbyte,
+            num_p2wkh_inputs=num_p2wkh,
+            num_np2wkh_inputs=num_np2wkh,
+            num_channels=num_channels,
+            has_change=create_anchor_output
+        )
+        anchor_change = anchor_reserve if create_anchor_output else 0
+        budget = sum(utxo.amount_sat for utxo in available_utxos) \
+            - anchor_change - fee
+        if budget < 0:
+            raise ValueError(f"Not enough funds for channel opening.")
+        change = anchor_change
+        return available_utxos, budget, change, fee
+
+    else:  # We try to spend a smaller amount than the given UTXO set.
+        # We need to include change either because funds are left over
+        # or we need to keep the anchor reserve.
+        create_change = True
+        if spend_all_utxos:  # user wants to batch all inputs together
+            num_p2wkh, num_np2wkh = count_input_types(utxos)
+            fee = calculate_fees(
+                sat_per_vbyte,
+                num_p2wkh_inputs=num_p2wkh,
+                num_np2wkh_inputs=num_np2wkh,
+                num_channels=num_channels,
+                has_change=create_change
+            )
+            utxo_sum = sum(utxo.amount_sat for utxo in utxos)
+            budget = min(total_amount_requested, utxo_sum - fee)
+            if budget < 0:
+                raise ValueError(f"Not enough funds for channel opening.")
+            change = utxo_sum - budget - fee
+            return utxos, budget, change, fee
+
+        else:  # we need to do coin selection
+            selected_utxos = []
+            utxo_sum = 0
+            for utxo in available_utxos:
+                utxo_sum += utxo.amount_sat
+                selected_utxos.append(utxo)
+                num_p2wkh, num_np2wkh = count_input_types(selected_utxos)
+                fee = calculate_fees(
+                    sat_per_vbyte,
+                    num_p2wkh_inputs=num_p2wkh,
+                    num_np2wkh_inputs=num_np2wkh,
+                    num_channels=num_channels,
+                    has_change=True
+                )
+                if total_amount_requested + fee + anchor_reserve <= utxo_sum:
+                    change = utxo_sum - total_amount_requested - fee
+                    return selected_utxos, total_amount_requested, change, fee
+    raise ValueError("Don't have enough funds.")
+
+
+class ChannelOpener(object):
+    """Opens multiple channels at once."""
+
+    def __init__(self, node: 'LndNode'):
+        self.node = node
+
+    def _parse_pubkeys(self, pubkeys: str) -> List[str]:
+        pubkeys = pubkeys.split(',')
+        pubkeys = [c.strip() for c in pubkeys]
+        return pubkeys
+
+    def _pubkeys_to_bytes(self, pubkeys: List[str]) -> List[bytes]:
+        return [bytes.fromhex(pubkey) for pubkey in pubkeys]
+
+    @staticmethod
+    def _parse_amounts(amounts: str) -> Optional[List[int]]:
+        if amounts:
+            amount_ints = amounts.split(',')
+            amount_ints = [int(a) for a in amount_ints]
+            return amount_ints
+        else:
+            return None
+
+    @staticmethod
+    def _parse_utxo_outpoints(utxos_str: str) -> Optional[List[UTXO]]:
+        if utxos_str:
+            utxo_strings = utxos_str.split(',')
+            utxos = []
+            for u in utxo_strings:
+                try:
+                    txid, output_index = u.split(':')
+                except ValueError:
+                    raise ValueError("utxo format is not of txid:index")
+                utxos.append(
+                    UTXO(txid=str(txid), output_index=int(output_index))
+                )
+            return utxos
+        else:
+            return None
+
+    def open_channels(self, *, pubkeys: str, amounts: str = None,
+                      utxos: Optional[str] = None, sat_per_vbyte=1,
+                      total_amount: Optional[int] = None, reckless=False,
+                      private=False):
+        """
+        Performs input checks on parameters and performs user interaction for
+        batch channel opening.
+
+        pubkeys: comma separated nodeid1,nodeid2,...
+        amounts: comma separated amount1,amount2,...
+        utxos: txid:output_idx,txid:output_idx,...
+        sat_per_vbyte: onchain fee rate
+        total_amount: if amounts are not specified, a total amount is
+            distributed to all peers
+
+        Steps:
+        1. connect to nodes
+        2. report about errors and demand actions (TODO)
+        3. check provided utxos (if any)
+        4. calculate budget without fees and anchor reserve
+        5. open channels
+
+        """
+        # Possible improvements:
+        # add close_addresses for upfront shutdown script
+        pubkeys = self._parse_pubkeys(pubkeys)
+        amounts = self._parse_amounts(amounts)
+
+        if amounts and total_amount:
+            raise ValueError("Specify either amounts or total amount.")
+
+        if amounts and len(amounts) != len(pubkeys):
+            raise ValueError("Number of amounts is not equal to number of"
+                             "node pubkeys.")
+        # 1. connect to nodes
+        try:
+            pubkeys_succeeded = self.node._connect_nodes(pubkeys)
+        except ConnectionRefusedError:
+            logger.info(">>> Could not connect to all nodes. Try to connect "
+                        "manually via 'lncli connect', then rerun.")
+            return
+
+        assert len(pubkeys) == len(pubkeys_succeeded)
+        pubkeys = self._pubkeys_to_bytes(pubkeys_succeeded)
+        num_channels = len(pubkeys)
+
+        # 2. report about errors
+        # TODO: report about connection errors and how to proceed
+        # maybe reduce number of peers, or suggest new list of peers that the
+        # user can copy-paste
+
+        # 3. check utxos
+        wallet_utxos = self.node.get_utxos()
+        wallet_balance = sum(utxo.amount_sat for utxo in wallet_utxos)
+        user_provided_utxos = self._parse_utxo_outpoints(utxos)
+
+        available_utxos = []
+        if user_provided_utxos:
+            for utxo in user_provided_utxos:
+                if utxo in wallet_utxos:
+                    # need to do index lookups here to also get additional info on the utxos
+                    available_utxos.append(wallet_utxos[wallet_utxos.index(utxo)])
+                else:
+                    raise ValueError(f"UTXO {utxo} is not controlled by the wallet")
+        else:
+            available_utxos = wallet_utxos
+        available_balance = sum(utxo.amount_sat for utxo in available_utxos)
+
+        if not available_utxos:
+            raise ValueError("no UTXOs available'")
+        logger.info(">>> Available UTXOs:")
+        for utxo in available_utxos:
+            logger.debug(f"    {utxo.txid}:{utxo.output_index} {utxo.amount_sat} sat")
+
+        if available_balance > wallet_balance - ANCHOR_RESERVE:
+            # the user included maybe too many UTXOs that may spend beyond the anchor reserve
+            logger.debug("    Need to potentially consider anchor outputs.")
+            anchor_reserve = ANCHOR_RESERVE
+        else:
+            anchor_reserve = 0
+
+        if (sum(utxo.amount_sat for utxo in available_utxos) - anchor_reserve) \
+                / num_channels < MIN_CHANNEL_SIZE:
+            raise ValueError(f"The total available funds are not enough to "
+                             f"fund {num_channels} channels with minimal size of "
+                             f"{MIN_CHANNEL_SIZE} sat. (Anchor reserve: "
+                             f"{anchor_reserve} sat.)")
+
+        # 4. calculate budget
+        # Amounts and total_amount are mutually exclusive. Total amount of None
+        # indicates a full spend.
+        if amounts:
+            total_amount = sum(amounts)
+            if total_amount < 100:
+                total_amount = None
+        elif total_amount:
+            amounts = [int(total_amount / num_channels) for _ in pubkeys]
+        else:
+            total_amount = None
+
+        # If the total amount doesn't resepect the anchor reserve, make it a full spend.
+        if total_amount and total_amount > available_balance - anchor_reserve:
+            total_amount = None
+
+        utxos, budget, change, fee = provide_coins(
+            utxos=available_utxos,
+            spend_all_utxos=bool(utxos),  # user provided some utxos
+            total_amount_requested=total_amount,
+            sat_per_vbyte=sat_per_vbyte,
+            num_channels=num_channels,
+            anchor_reserve=anchor_reserve,
+        )
+        logger.info(">>> Used UTXOs:")
+        for utxo in utxos:
+            logger.info(f"    {utxo.txid}:{utxo.output_index} {utxo.amount_sat} sat")
+        logger.info(f">>> Channels will be {'private' if private else 'public'}.")
+
+        def rescale(amounts: List[int], rescaled_total_amount: int) -> List[int]:
+            """Rescales list of amounts to amounts with sum of
+            rescaled_total_amount, fixing also rounding errors."""
+            tot_amt = sum(amounts)
+            amounts = [rescaled_total_amount * a // tot_amt for a in amounts]
+            # handle rounding errors
+            diff = rescaled_total_amount - sum(amounts)
+            amounts[-1] += diff
+            return amounts
+
+        if not total_amount:
+            if not amounts:
+                # distribute the total budget equally over all channels
+                amounts = [int(budget / num_channels) for _ in pubkeys]
+            else:
+                amounts = rescale(amounts, budget)
+
+        logger.info(f"    Channel capacities: {amounts} sat ({sum(amounts)} sat total).")
+        logger.info(f"    Fees: {fee} sat ({sat_per_vbyte} sat/vbyte).")
+        logger.info(f"    Change: {change} sat.")
+
+        # TODO: check connected node's features and allow wumbo channels
+        # if own node supports it
+        for amount in amounts:
+            if amount > WUMBO_LIMIT:
+                raise ValueError("Wumbo channels (capacity bigger than 16777215 sat) not yet supported.")
+
+        # 5. open channels
+        try:
+            self.node.open_channels(
+                pubkeys=pubkeys,
+                amounts_sat=amounts,
+                change_sat=change,
+                utxos=utxos,
+                reckless=reckless,
+                private=private,
+                sat_per_vbyte=sat_per_vbyte,
+            )
+        except Exception as e:
+            logger.exception(e)
+            pass

--- a/lndmanage/lib/psbt.py
+++ b/lndmanage/lib/psbt.py
@@ -1,0 +1,85 @@
+"""PSBT (BIP 174) utilities.
+https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+Sources:
+https://github.com/Jason-Les/python-psbt
+Programming Bitcoin book, Jimmy Song
+"""
+from io import BytesIO
+from typing import List, Tuple, Optional
+
+PSBT_MAGIC_SEPARATOR = b'psbt' + b'\xFF'
+PSBT_GLOBAL_UNSIGNED_TX = b'\x00'
+
+
+def little_endian_to_int(b: bytes):
+    '''little_endian_to_int takes bytes sequence as a little-endian number.
+    Returns an integer'''
+    # use the from_bytes method of int
+    return int.from_bytes(b, 'little')
+
+
+def read_varint(s: BytesIO):
+    '''read_varint reads a variable integer from a stream'''
+    i = s.read(1)[0]
+    if i == 0xfd:
+        # 0xfd means the next two bytes are the number
+        return little_endian_to_int(s.read(2))
+    elif i == 0xfe:
+        # 0xfe means the next four bytes are the number
+        return little_endian_to_int(s.read(4))
+    elif i == 0xff:
+        # 0xff means the next eight bytes are the number
+        return little_endian_to_int(s.read(8))
+    else:
+        # anything else is just the integer
+        return i
+
+
+def parse_key_value(stream: BytesIO) -> Tuple[Optional[bytes], Optional[bytes]]:
+    key_length = read_varint(stream)
+    # a key length of 0 represents a separator
+    if key_length == 0:
+        return None, None
+    key = stream.read(key_length)
+    val_length = read_varint(stream)
+    val = stream.read(val_length)
+    return key, val
+
+
+def extract_psbt_inputs_outputs(psbt: bytes) -> Tuple[int, int, List[int]]:
+    """Parses only the transaction in the global map of a PSBT representing
+    an unsigned transaction and returns the number of inputs, outputs, and the
+    individual amounts."""
+    stream = BytesIO(psbt)
+    # parse header
+    header = stream.read(5)
+    if header != PSBT_MAGIC_SEPARATOR:
+        raise ValueError("wrong psbt header")
+
+    # parse global
+    key, value = parse_key_value(stream)
+    if key != PSBT_GLOBAL_UNSIGNED_TX:
+        raise NotImplementedError("Can't parse PSBTs that contain other data than unsigned transactions.")
+
+    # parse transaction
+    transaction_stream = BytesIO(value)
+    version = little_endian_to_int(transaction_stream.read(4))
+
+    # parse inputs
+    num_inputs = read_varint(transaction_stream)
+    for _ in range(num_inputs):
+        prev_tx = transaction_stream.read(32)[::-1]
+        prev_index = little_endian_to_int(transaction_stream.read(4))
+        script_sig_length = read_varint(transaction_stream)
+        script_sig = transaction_stream.read(script_sig_length)
+        sequence = little_endian_to_int(transaction_stream.read(4))
+
+    # parse outputs
+    num_outputs = read_varint(transaction_stream)
+    output_amounts = []
+    for _ in range(num_outputs):
+        amount = little_endian_to_int(transaction_stream.read(8))
+        script_pubkey_length = read_varint(transaction_stream)
+        script_pubkey = transaction_stream.read(script_pubkey_length)
+        output_amounts.append(amount)
+    return num_inputs, num_outputs, output_amounts

--- a/lndmanage/lib/types.py
+++ b/lndmanage/lib/types.py
@@ -1,0 +1,31 @@
+from enum import Enum
+from dataclasses import dataclass, field
+
+
+class AddressType(Enum):
+    WITNESS_PUBKEY_HASH = 0
+    NESTED_PUBKEY_HASH = 1
+
+
+@dataclass(order=True)
+class UTXO:
+    sort_index: int = field(init=False, repr=False)
+    txid: str
+    output_index: int
+    amount_sat: int = None
+    transaction_type: AddressType = None
+
+    def __post_init__(self):
+        self.sort_index = self.amount_sat
+
+    def __hash__(self):
+        return hash(self.txid) + hash(self.output_index)
+
+    def __eq__(self, other: 'UTXO'):
+        if self.txid == other.txid and self.output_index == other.output_index:
+            return True
+        else:
+            return False
+
+    def __str__(self):
+        return f"{self.txid}:{self.output_index} {self.amount_sat} sat"

--- a/test/test_openchannels.py
+++ b/test/test_openchannels.py
@@ -1,0 +1,214 @@
+"""
+Integration tests for batch opening of channels.
+"""
+import time
+from unittest import TestCase
+
+from lndmanage import settings
+from lndmanage.lib import openchannels
+
+from test.testnetwork import TestNetwork
+
+from test.testing_common import (
+    lndmanage_home,
+    test_graphs_paths,
+)
+
+import logging.config
+
+settings.set_lndmanage_home_dir(lndmanage_home)
+logging.config.dictConfig(settings.logger_config)
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+logger.handlers[0].setLevel(logging.DEBUG)
+
+
+def confirm_transactions(testnet):
+    for _ in range(6):
+        testnet.bitcoind.mine_blocks(1)
+        time.sleep(0.2)
+
+
+class Batchopen(TestNetwork):
+    """Tests batched channel opening."""
+
+    network_definition = test_graphs_paths['star_ring_3_liquid']
+
+    def graph_test(self):
+        self.assertEqual(4, self.master_node_networkinfo['num_nodes'])
+        self.assertEqual(6, self.master_node_networkinfo['num_channels'])
+
+    def test_batchopen(self):
+        channel_opener = openchannels.ChannelOpener(self.lndnode)
+        channel_partner_pubkeys = [self.testnet.ln_nodes['B'], self.testnet.ln_nodes['C']]
+
+        # prepare user input
+        pubkey_input = ",".join([
+            channel_partner.pubkey for channel_partner in channel_partner_pubkeys
+        ])
+
+        with self.subTest(msg="(implicit), using amounts, change created, high fees"):
+            amount1 = 111_111
+            amount2 = 222_222
+
+            wallet_utxos_before = self.lndnode.get_utxos()
+            channels_before = self.lndnode.get_open_channels()
+            channel_opener.open_channels(
+                pubkeys=pubkey_input,
+                amounts=f"{amount1},{amount2}",
+                reckless=True,
+                sat_per_vbyte=20,
+            )
+            confirm_transactions(self.testnet)
+            wallet_utxos_after = self.lndnode.get_utxos()
+            channels_after = self.lndnode.get_open_channels()
+
+            self.assertEqual(2, len(channels_after) - len(channels_before))
+            self.assertEqual(0, len(wallet_utxos_before) - len(wallet_utxos_after))
+
+            channel_capacities_after = [channel['capacity'] for channel in channels_after.values()]
+            self.assertIn(amount1, channel_capacities_after)
+            self.assertIn(amount2, channel_capacities_after)
+
+        with self.subTest(msg="(implicit), total amount, private, change created"):
+            total_amount = 4_444_444
+
+            wallet_utxos_before = self.lndnode.get_utxos()
+            channels_before = self.lndnode.get_open_channels()
+            channel_opener.open_channels(
+                pubkeys=pubkey_input,
+                total_amount=total_amount,
+                reckless=True,
+                private=True,
+            )
+            confirm_transactions(self.testnet)
+            wallet_utxos_after = self.lndnode.get_utxos()
+            channels_after = self.lndnode.get_open_channels()
+
+            self.assertEqual(2, len(channels_after) - len(channels_before))
+            self.assertEqual(0, len(wallet_utxos_before) - len(wallet_utxos_after))
+
+            total_capacity_before = sum([channel['capacity'] for channel in channels_before.values()])
+            total_capacity_after = sum([channel['capacity'] for channel in channels_after.values()])
+            self.assertEqual(total_amount, total_capacity_after - total_capacity_before)
+            num_private_channels = len([True for v in channels_after.values() if v['private']])
+            self.assertEqual(2, num_private_channels)
+
+        with self.subTest(msg="(explicit), spend fully, no change created"):
+            address = self.testnet.master_node.getaddress()
+            self.testnet.bitcoind.sendtoaddress(address, 0.10_000_000)
+            confirm_transactions(self.testnet)
+
+            wallet_utxos_before = self.lndnode.get_utxos()
+            channels_before = self.lndnode.get_open_channels()
+            # maybe make sure we select the correct utxo
+            spent_utxo = wallet_utxos_before[0]
+            utxo_input = f"{spent_utxo.txid}:{spent_utxo.output_index}"
+            channel_opener.open_channels(
+                utxos=utxo_input,
+                pubkeys=pubkey_input,
+                reckless=True,
+            )
+            confirm_transactions(self.testnet)
+            wallet_utxos_after = self.lndnode.get_utxos()
+            channels_after = self.lndnode.get_open_channels()
+
+            self.assertEqual(2, len(channels_after) - len(channels_before))
+            self.assertEqual(1, len(wallet_utxos_before) - len(wallet_utxos_after))
+
+            self.assertNotIn(spent_utxo, wallet_utxos_after)
+
+        # clear wallet, but keep anchor reserves, leaves 50000 sat
+        self.testnet.master_node.rpc(["sendcoins", "--sweepall", "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"])
+        confirm_transactions(self.testnet)
+
+        with self.subTest(msg="implicit coins, relative amounts, anchor reserve created"):
+            address = self.testnet.master_node.getaddress()
+            self.testnet.bitcoind.sendtoaddress(address, 0.10_000_000)
+            confirm_transactions(self.testnet)
+
+            wallet_utxos_before = self.lndnode.get_utxos()
+            channels_before = self.lndnode.get_open_channels()
+            channel_opener.open_channels(
+                amounts="1,2",
+                pubkeys=pubkey_input,
+                reckless=True,
+            )
+            confirm_transactions(self.testnet)
+            wallet_utxos_after = self.lndnode.get_utxos()
+            channels_after = self.lndnode.get_open_channels()
+
+            self.assertEqual(2, len(channels_after) - len(channels_before))
+            self.assertEqual(1, len(wallet_utxos_before) - len(wallet_utxos_after))
+
+            wallet_utxo_amounts = [utxo.amount_sat for utxo in wallet_utxos_after]
+            self.assertIn(openchannels.ANCHOR_RESERVE, wallet_utxo_amounts)
+
+        with self.subTest(msg="implicit coins, nested-P2WKH, too large amounts"):
+            amount1 = 5_000_000
+            amount2 = 6_000_000
+            address = self.testnet.master_node.getaddress(address_type='np2wkh')
+            self.testnet.bitcoind.sendtoaddress(address, 0.10_000_000)
+            confirm_transactions(self.testnet)
+
+            wallet_utxos_before = self.lndnode.get_utxos()
+            channels_before = self.lndnode.get_open_channels()
+            channel_opener.open_channels(
+                amounts=f"{amount1},{amount2}",
+                pubkeys=pubkey_input,
+                reckless=True,
+            )
+            confirm_transactions(self.testnet)
+            wallet_utxos_after = self.lndnode.get_utxos()
+            channels_after = self.lndnode.get_open_channels()
+
+            self.assertEqual(2, len(channels_after) - len(channels_before))
+            self.assertEqual(1, len(wallet_utxos_before) - len(wallet_utxos_after))
+
+            total_capacity_before = sum([channel['capacity'] for channel in channels_before.values()])
+            total_capacity_after = sum([channel['capacity'] for channel in channels_after.values()])
+            # test that we have reduced the amounts
+            self.assertGreater(amount1 + amount2, total_capacity_after - total_capacity_before)
+
+        with self.subTest(msg="implicit coins, nested-P2WKH, too large amounts"):
+            address = self.testnet.master_node.getaddress(address_type='np2wkh')
+            self.testnet.bitcoind.sendtoaddress(address, 0.10_000_000)
+            confirm_transactions(self.testnet)
+            total_amount = 20_000_000
+            wallet_utxos_before = self.lndnode.get_utxos()
+            channels_before = self.lndnode.get_open_channels()
+            channel_opener.open_channels(
+                total_amount=total_amount,
+                pubkeys=pubkey_input,
+                reckless=True,
+            )
+            confirm_transactions(self.testnet)
+            wallet_utxos_after = self.lndnode.get_utxos()
+            channels_after = self.lndnode.get_open_channels()
+
+            self.assertEqual(2, len(channels_after) - len(channels_before))
+            self.assertEqual(1, len(wallet_utxos_before) - len(wallet_utxos_after))
+
+            total_capacity_before = sum([channel['capacity'] for channel in channels_before.values()])
+            total_capacity_after = sum([channel['capacity'] for channel in channels_after.values()])
+            # test that we have reduced the total amount
+            self.assertGreater(total_amount, total_capacity_after - total_capacity_before)
+
+        with self.subTest(msg="implicit coins, full spend, wumbo violation"):
+            address = self.testnet.master_node.getaddress()
+            self.testnet.bitcoind.sendtoaddress(address, (2 * openchannels.WUMBO_LIMIT + 1000) * 1E-8)
+
+            confirm_transactions(self.testnet)
+            self.assertRaises(
+                ValueError, channel_opener.open_channels,
+                pubkeys=pubkey_input,
+                reckless=True,
+            )
+
+
+class FeeTest(TestCase):
+    def test_fee_estimation(self):
+        self.assertNotEqual(165, openchannels.calculate_fees(sat_per_vbyte=1, num_p2wkh_inputs=1, num_np2wkh_inputs=0, num_channels=2, has_change=False))
+        self.assertNotEqual(196, openchannels.calculate_fees(sat_per_vbyte=1, num_p2wkh_inputs=1, num_np2wkh_inputs=0, num_channels=2, has_change=True))
+        self.assertEqual(227, openchannels.calculate_fees(sat_per_vbyte=1, num_p2wkh_inputs=1, num_np2wkh_inputs=0, num_channels=2, has_change=True))  # reproduce bug in lnd
+        self.assertEqual(196, openchannels.calculate_fees(sat_per_vbyte=1, num_p2wkh_inputs=1, num_np2wkh_inputs=0, num_channels=2, has_change=False))  # reproduce bug in lnd

--- a/test/test_psbt.py
+++ b/test/test_psbt.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+from lndmanage.lib import psbt
+from binascii import unhexlify, a2b_base64
+
+
+class PSBTTest(TestCase):
+    def test_psbt_magic(self):
+        self.assertEqual(bytes.fromhex('70736274FF'), psbt.PSBT_MAGIC_SEPARATOR)
+
+    def test_psbt_from_bytes(self):
+        data = a2b_base64("cHNidP8BAIkCAAAAAW18fk+d7Xn+uwhZbaB+QqCAL8hJH58FShnRPbJnEuBtAAAAAAD/////Asef/AEAAAAAIgAgd/G0Fd8Bj6JPRZe3l0jTyNymOS+MzCuF6R6afTUJlb+QP/kDAAAAACIAIHm/fFMVYD11fLjoRMGLYFCkqP8XnFKusmHfstlELelHAAAAAAABAN4CAAAAAAEBPVfLJjNQObnakrPrX7dFrViGGPhbdTLQdAZg8FLeMvYBAAAAAP7///8CAOH1BQAAAAAWABS6BvZzsfWYFhsFXzaUDQhHnBfRddmXgR0BAAAAFgAUV4AyH5gnj5MPgyOVERAkgpMp0mUCRzBEAiAOXvriTqHmFxWv6sBKPhNnsToTr24xUssEEKvI2orduQIgUjbrfAFSIDWWhe8WXwTbMeWB9IoHevu1snICGsAMoucBIQJ21ss2GSM0fV8F3ILVqzW3SNdunSNjSNh1CGQuqwq7q78AAAABAR8A4fUFAAAAABYAFLoG9nOx9ZgWGwVfNpQNCEecF9F1AQMEAQAAACIGA0DnWsAOWoFkVk9RVhWWV95PWI8PEuaT5EcT403nRwFMGAAAAABUAACAAAAAgAAAAIAAAAAABQAAAAAAAA==")
+        num_inputs, num_outputs, amounts = psbt.extract_psbt_inputs_outputs(data)
+        self.assertEqual((1, 2, [33333191, 66666384]), (num_inputs, num_outputs, amounts))


### PR DESCRIPTION
Introduces a new command `openchannels` with the intent of batching channel opens and implementing coin control, meaning one can select the UTXOs to spend from. Batching is implemented using LNDs support for PSBTs, so there is no external wallet required. The command expects a comma-separated list of public node ids as a minimal input. UTXOs and amounts can be specified as a comma-separated outpoint string.
The command will perform connection checks automatically in the setup phase. Once the setup phase is passed, channel opening is initiated. When everything goes well, before final signing and broadcasting, the user is asked to confirm the channel opening. Anchor reserve outputs are created/respected automatically.

The command has several modes of operation for specifying amounts and utxos:
* Specifying UTXOs defines a budget
* No amount is given: spend all UTXOs and distribute them equally to the channels - no change created
* Specify a total amount and no UTXOs: all UTXOs will be spent - no change created
* Specify amounts for channels and no UTXOs: all UTXOs will be spent:
  * (relative amounts) amounts are smaller than `100`: relative amounts are rescaled to fit all UTXOs - no change created
  * (absolute amounts) amounts are larger than `100`: if sum of amounts is smaller than the UTXO budget, change is created, if sum of amounts is larger than UTXO budget, the amount is rescaled such that no change is created

The user can decide if the opening should be private (unannounced) or public (announced).

TODO:
- [x] Insert a timer to track the elapsed time
- [x] Handle anchor reserves
- [x] Decode PSBT for crosscheck
- [x] Handle nested P2WKH inputs
- [x] Reproduce LND fee estimation bug
- [ ] Report bug to LND repo
- [x] final testing and code cleanup
- Implement a new command for UTXO locking/listing (in another PR)