### PR TITLE
Channel fee optimization

### DIFF
--- a/lndmanage/lib/fee_setting.py
+++ b/lndmanage/lib/fee_setting.py
@@ -1,70 +1,380 @@
-import lndmanage.grpc_compiled.rpc_pb2 as ln
-
+import json
 import logging
+import os
+import time
+from typing import Tuple, List, TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from lndmanage.lib.node import LndNode
+
+from lndmanage import settings
+from lndmanage.lib.user import yes_no_question
+from lndmanage.lib.forwardings import ForwardingAnalyzer
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-CLTV = 40
+optimization_parameters = {
+    'cltv': 14,  # blocks
+    'min_base_fee': 0,  # msat
+    'max_base_fee': 5000,  # msat
+    'min_fee_rate': 0.000005,
+    'max_fee_rate': 0.005000,
+    'delta_max': 1.5,
+    'delta_min_up': 0.05,
+    'delta_min_dn': 0.50,
+    'r_t': 100000 / 7,  # sat / day  TODO: optimize by statistical analysis
+    'local_balance_reserve': 500000,  # sat
+    'delta_b_min': 0.25,
+    'delta_b_max': 0.50,
+    'delta_b': 0.5,
+    'n_t': 4 / 7,
+}
 
 
-def set_fees_by_balancedness(
-        node, base_unbalanced_msat, rate_unbalanced_decimal, base_balanced_msat, rate_balanced_decimal,
-        unbalancedness=0.90):
-    """
-    Can be used to set fees differently for balanced and unbalanced channels.
-    TODO: refactor out lnd api calls into :class:`lib.node.LndNode`
+def delta_min(params: dict, local_balance: int, capacity: int):
+    """The capping from below for the delta_demand function."""
+    if not local_balance <= capacity:
+        raise ValueError(
+            f"local balance must be lower than capacity "
+            f"{local_balance} / {capacity}")
 
-    :param node: :class:`lib.node.LndNode` instance
-    :param base_unbalanced_msat: int
-    :param rate_unbalanced_decimal: float (e.g. 0.00001 = 0.001 %)
-    :param base_balanced_msat: int
-    :param rate_balanced_decimal: float (e.g. 0.00001 = 0.001 %)
-    :param unbalancedness: float between 0 ... 1 (0: very balanced, 1: very unbalanced)
-    """
+    # if we have small channels, which can't respect the reserve, lower the
+    # reserve
+    if params['local_balance_reserve'] > capacity // 2:
+        reserve = capacity // 3
+    else:
+        reserve = params['local_balance_reserve']
 
-    channels = node.get_unbalanced_channels()
-    logger.info(f"-------- unbalanced channels (|ub| > {unbalancedness}) ---------")
-    channels.sort(key=lambda x: abs(x['unbalancedness']), reverse=True)
-    print_divide = 0
+    # if local balance is below balance reserve, start to charge more fees
+    if local_balance < params['local_balance_reserve']:
+        x = params['delta_min_up'] / reserve
+        return -x * (local_balance - reserve) + 1
 
-    for c in channels:
-        logger.info(f"|ub|: {abs(c['unbalancedness']):1.4f} c: {c['chan_id']} a: {c['alias']}")
+    # if local balance is above balance reserve, charge less fees
+    else:
+        x = params['delta_min_dn'] / (
+                capacity - reserve)
+        return -x * (local_balance - reserve) + 1
 
-        cp_parts = c['channel_point'].split(':')
 
-        channel_point = ln.ChannelPoint(funding_txid_str=cp_parts[0], output_index=int(cp_parts[1]))
+def delta_demand(params: dict, time_interval: float, amount_out: float,
+                 local_balance: int, capacity:int) -> float:
+    """Calculates a change factor for a channel by taking into account
+    the amount transacted in a time interval compared to a target rate.
 
-        if abs(c['unbalancedness']) > unbalancedness:  # unbalanced
-            new_base = base_unbalanced_msat
-            new_rate = rate_unbalanced_decimal
-        else:  # balanced
-            if print_divide == 0:
-                logger.info(f"-------- balanced channels (|ub| < {unbalancedness}) --------")
-                print_divide = 1
+    The higher the amount forwarded, the larger the fee rate should be.
+    :param params: fee optimization parameters
+    :param time_interval: time interval in days
+    :param amount_out: amount transacted outwards for the channel in sat
+    :param local_balance: local balance in sat
+    :param capacity: capacity in sat
+    :return: demand adjustment factor"""
+    r = amount_out / time_interval
+    r_t = params['r_t']
 
-            new_base = base_balanced_msat
-            new_rate = rate_balanced_decimal
+    logger.info(
+        f"    Outward forwarded amount: {amount_out:6.0f} "
+        f"(rate {r:5.0f} / target rate {r_t:5.0f})")
 
-        update_request = ln.PolicyUpdateRequest(
-            chan_point=channel_point,
-            base_fee_msat=new_base,
-            fee_rate=new_rate,
-            time_lock_delta=CLTV,
-        )
-        logger.debug(update_request)
-        # node._stub.UpdateChannelPolicy(request=update_request)
+    m = params['delta_min_dn']
+
+    c = 1. + m * (r / r_t - 1.)
+
+    mc = delta_min(params, local_balance, capacity)
+
+    # cap from below
+    if c < mc:
+        return mc
+    # cap from above
+    elif c > params['delta_max']:
+        return params['delta_max']
+    else:
+        return c
+
+
+class FeeSetter(object):
+    """Class for fee optimization."""
+
+    def __init__(self, node: 'LndNode', from_days_ago=7,
+                 parameters: Optional[dict] = None):
+        """
+        :param node: node instance
+        :param from_days_ago: forwarding history is taken over the past
+            from_days_ago days
+        :param parameters: fee algo parameters"""
+
+        # by default, channel fees are updated, not initialized
+        self.node = node
+
+        self.history_path = os.path.join(settings.home_dir, 'fee_history.log')
+
+        if parameters is None:
+            self.params = optimization_parameters
+        else:
+            self.params = parameters
+
+        # initialize fee setter
+        self.forwarding_analyzer = ForwardingAnalyzer(node)
+        self.channel_fee_policies = node.get_channel_fee_policies()
+
+        # determine time interval for forwardings analyzer to look back
+        # for transactions
+        self.time_end = time.time()
+        self.time_start = self.time_end - from_days_ago * 24 * 60 * 60
+        self.time_interval_days = from_days_ago
+        self.forwarding_analyzer.initialize_forwarding_data(
+            self.time_start, self.time_end)
+
+        # get channel info
+        self.channels = self.node.get_all_channels()
+        self.channels_forwarding_stats = \
+            self.forwarding_analyzer.get_forwarding_statistics_channels()
+
+    def set_fees(self, init=False, reckless=False) -> List[dict]:
+        """Sets channel fee policies considering different metrics like
+        unbalancedness and demand.
+
+        :param init: true if fees are set initially with this method
+        :param reckless: if set, there won't be any user interaction
+        :return: fee changes statistics"""
+
+        channel_fee_policies, stats = self.new_fee_policies(init)
+
+        if reckless:
+            set_fees = True
+        else:
+            logger.info("Do you want to set these fees? Enter [yes/no]:")
+            set_fees = yes_no_question()
+
+        if set_fees:
+            self.node.set_channel_fee_policies(channel_fee_policies)
+            self.append_to_history(stats)
+            logger.info("Have set new fee policy.")
+        else:
+            logger.info("Didn't set new fee policy.")
+
+        return stats
+
+    def new_fee_policies(self, init=False) -> Tuple[dict, list]:
+        """Calculates and reports the changes to the new fee policy.
+
+        :param init: when true, fee policy is initialized
+        :return: (new channel policies, fee update statistics)"""
+        logger.info("Determining new channel policies based on demand.")
+        logger.info(
+            "Every channel will have a base fee of %d msat and cltv "
+            "of %d.", self.params['min_base_fee'], self.params['cltv'])
+        channel_fee_policies = {}
+
+        stats = []
+
+        # loop over channel peers
+        for pk, cs in self.node.pubkey_to_channel_map().items():
+            logger.info(f">>> Fee optimization for node {pk} "
+                        f"({self.node.network.node_alias(pk)}):")
+            # loop over channels with peer
+            peer_capacity = 0
+            peer_local_balance = 0
+            peer_number_forwardings_out = 0
+            peer_total_forwarding_out = 0
+            cumul_base_fee = 0
+            cumul_fee_rate = 0
+
+            # accumulate information on a per peer basis
+            for channel_id in cs:
+                # collect channel info and stats
+                channel_data = self.channels[channel_id]
+                channel_stats = self.channels_forwarding_stats.get(
+                    channel_id,
+                    None
+                )
+
+                if channel_stats is None:
+                    number_forwardings_out = 0
+                    total_forwarding_out = 0
+                else:
+                    number_forwardings_out = channel_stats[
+                        'number_forwardings_out']
+                    total_forwarding_out = channel_stats[
+                        'total_forwarding_out']
+
+                peer_capacity += channel_data['capacity']
+                peer_local_balance += channel_data['local_balance']
+                peer_number_forwardings_out += number_forwardings_out
+                peer_total_forwarding_out += total_forwarding_out
+
+                cumul_fee_rate += \
+                    self.channel_fee_policies[
+                        channel_data['channel_point']]['fee_rate']
+                cumul_base_fee += \
+                    self.channel_fee_policies[
+                        channel_data['channel_point']]['base_fee_msat']
+
+            logger.info(f"    Channels with peer: {len(cs)}, "
+                        f"total capacity: {peer_capacity}, "
+                        f"total local balance: {peer_local_balance}")
+
+            # calculate average base fee and fee rate
+            base_fee_msat = int(cumul_base_fee / len(cs))
+            fee_rate = round(cumul_fee_rate / len(cs), 6)
+
+            # FEE RATES
+            factor_demand = delta_demand(
+                self.params,
+                self.time_interval_days,
+                peer_total_forwarding_out,
+                peer_local_balance, peer_capacity
+            )
+
+            # round down to 6 digits, as this is the expected data for
+            # the api
+            fee_rate_new = round(fee_rate * factor_demand, 6)
+
+            # if the fee rate is too low, cap it, as we don't want to
+            # necessarily have too low fees, limit also from top
+            fee_rate_new = max(self.params['min_fee_rate'], fee_rate_new)
+
+            # if the fee rate is too high, cap it, as we don't want to
+            # loose channels due to other parties thinking we are too greedy
+            fee_rate_new = min(self.params['max_fee_rate'], fee_rate_new)
+
+            # if we initialize the fee optimization, we want to start with
+            # reasonable starting values
+            if init:
+                fee_rate_new = self.params['max_fee_rate'] / 2
+
+            # BASE FEES
+            factor_base_fee = self.factor_demand_base_fee(
+                peer_number_forwardings_out)
+            base_fee_msat_new = base_fee_msat * factor_base_fee
+            if init:
+                base_fee_msat_new = self.params['min_base_fee']
+            else:
+                # limit from below
+                base_fee_msat_new = int(
+                    max(self.params['min_base_fee'], base_fee_msat_new))
+                # limit from above
+                base_fee_msat_new = int(
+                    min(self.params['max_base_fee'], base_fee_msat_new))
+
+            logger.info("    Fee rate change: %1.6f -> %1.6f (factor %1.3f)",
+                        fee_rate, fee_rate_new, factor_demand)
+
+            logger.info("    Base fee change: %4d -> %4d (factor %1.3f)",
+                        base_fee_msat, base_fee_msat_new, factor_base_fee)
+
+            # second loop through channels
+            for channel_id in cs:
+                channel_data = self.channels[channel_id]
+                channel_stats = self.channels_forwarding_stats.get(
+                    channel_id,
+                    None
+                )
+                if channel_stats is None:
+                    flow = 0
+                    fees_sat = 0
+                    total_forwarding_in = 0
+                    total_forwarding_out = 0
+                    number_forwardings = 0
+                    number_forwardings_out = 0
+                else:
+                    flow = channel_stats['flow_direction']
+                    fees_sat = channel_stats['fees_total'] / 1000
+                    total_forwarding_in = channel_stats['total_forwarding_in']
+                    total_forwarding_out = channel_stats[
+                        'total_forwarding_out']
+                    number_forwardings = channel_stats['number_forwardings']
+                    number_forwardings_out = channel_stats[
+                        'number_forwardings_out']
+
+                lb = channel_data['local_balance']
+                ub = channel_data['unbalancedness']
+                capacity = channel_data['capacity']
+
+                logger.info("  > Statistics for channel %s:", channel_id)
+                logger.info(
+                    "    ub: %0.2f, flow: %0.2f, fees: %1.3f sat, "
+                    "cap: %d sat, lb: %d sat, nfwd: %d, in: %d sat, "
+                    "out: %d sat.", ub, flow, fees_sat, capacity, lb,
+                    number_forwardings, total_forwarding_in,
+                    total_forwarding_out)
+
+                stats.append({
+                    'date': self.time_end,
+                    'channelid': channel_id,
+                    'total_in': total_forwarding_in,
+                    'total_out': total_forwarding_out,
+                    'lb': lb,
+                    'ub': ub,
+                    'flow': flow,
+                    'fees': fees_sat,
+                    'cap': capacity,
+                    'fdem': factor_demand,
+                    'fr': self.channel_fee_policies[
+                        channel_data['channel_point']]['fee_rate'],
+                    'frn': fee_rate_new,
+                    'nfwd': number_forwardings,
+                    'nfwdo': number_forwardings_out,
+                    'fbase': factor_base_fee,
+                    'bf': self.channel_fee_policies[
+                        channel_data['channel_point']]['base_fee_msat'],
+                    'bfn': base_fee_msat_new,
+                })
+
+                channel_fee_policies[channel_data['channel_point']] = {
+                    'base_fee_msat': base_fee_msat_new,
+                    'fee_rate': fee_rate_new,
+                    'cltv': self.params['cltv'],
+                }
+            logger.info("")
+        return channel_fee_policies, stats
+
+    def factor_demand_base_fee(self, num_fwd_out: int) -> float:
+        """Calculates a change factor by taking into account the number of
+        transactions transacted in a time interval compared to a fixed number
+        of transactions.
+
+        :param num_fwd_out: number of outward forwardings
+        :return: [1-c_max, 1+c_max]"""
+        logger.info(
+            "    Number of outward forwardings: %6.0f", num_fwd_out)
+
+        n = num_fwd_out / self.time_interval_days
+        delta = 1 + optimization_parameters['delta_b'] * (
+                n / optimization_parameters['n_t'] - 1)
+
+        delta = max(1 - optimization_parameters['delta_b_min'],
+                    min(delta, 1 + optimization_parameters['delta_b_max']))
+        return delta
+
+    def append_to_history(self, stats: List[dict]):
+        """append_history adds the fee setting statistics to a pickle file.
+
+        :param stats: fee statistics"""
+        logger.debug("Saving fee setting stats to fee history.")
+        with open(self.history_path, 'a') as f:
+            json.dump(stats, f)
+            f.write('\n')
+
+    def read_history(self) -> List[dict]:
+        """read_history is a function for unpickling the fee setting history.
+
+        :return: list of fee setting statistics
+        :rtype: list[dict]"""
+        with open(self.history_path, 'r') as f:
+            history = []
+            for i, line in enumerate(f):
+                history.append(json.loads(line))
+        return history
 
 
 if __name__ == '__main__':
     from lndmanage.lib.node import LndNode
     import logging.config
-    from lndmanage import settings
 
     logging.config.dictConfig(settings.logger_config)
 
-    nd = LndNode()
-
-    set_fees_by_balancedness(
-        nd, base_unbalanced_msat=0, rate_unbalanced_decimal=0.000001,
-        base_balanced_msat=40, rate_balanced_decimal=0.000050)
-
+    nd = LndNode('/home/user/.lndmanage/config.ini')
+    fee_setter = FeeSetter(nd)
+    fee_setter.set_fees()

--- a/lndmanage/lib/fee_setting.py
+++ b/lndmanage/lib/fee_setting.py
@@ -16,20 +16,20 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 optimization_parameters = {
-    'cltv': 40,  # blocks
-    'min_base_fee': 0,  # msat
-    'max_base_fee': 5000,  # msat
-    'min_fee_rate': 0.000005,
-    'max_fee_rate': 0.005000,
-    'delta_max': 1.5,
-    'delta_min_up': 0.05,
-    'delta_min_dn': 0.50,
-    'r_t': 100000 / 7,  # sat / day  TODO: optimize by statistical analysis
-    'local_balance_reserve': 500000,  # sat
-    'delta_b_min': 0.25,
-    'delta_b_max': 0.50,
-    'delta_b': 0.5,
-    'n_t': 4 / 7,
+    "cltv": 40,  # blocks
+    "min_base_fee": 0,  # msat
+    "max_base_fee": 5000,  # msat
+    "min_fee_rate": 0.000005,
+    "max_fee_rate": 0.005000,
+    "delta_max": 1.5,
+    "delta_min_up": 0.05,
+    "delta_min_dn": 0.50,
+    "r_t": 100000 / 7,  # sat / day  TODO: optimize by statistical analysis
+    "local_balance_reserve": 500000,  # sat
+    "delta_b_min": 0.25,
+    "delta_b_max": 0.50,
+    "delta_b": 0.5,
+    "n_t": 4 / 7,
 }
 
 
@@ -38,29 +38,34 @@ def delta_min(params: dict, local_balance: int, capacity: int):
     if not local_balance <= capacity:
         raise ValueError(
             f"local balance must be lower than capacity "
-            f"{local_balance} / {capacity}")
+            f"{local_balance} / {capacity}"
+        )
 
     # if we have small channels, which can't respect the reserve, lower the
     # reserve
-    if params['local_balance_reserve'] > capacity // 2:
+    if params["local_balance_reserve"] > capacity // 2:
         reserve = capacity // 3
     else:
-        reserve = params['local_balance_reserve']
+        reserve = params["local_balance_reserve"]
 
     # if local balance is below balance reserve, start to charge more fees
-    if local_balance < params['local_balance_reserve']:
-        x = params['delta_min_up'] / reserve
+    if local_balance < params["local_balance_reserve"]:
+        x = params["delta_min_up"] / reserve
         return -x * (local_balance - reserve) + 1
 
     # if local balance is above balance reserve, charge less fees
     else:
-        x = params['delta_min_dn'] / (
-                capacity - reserve)
+        x = params["delta_min_dn"] / (capacity - reserve)
         return -x * (local_balance - reserve) + 1
 
 
-def delta_demand(params: dict, time_interval: float, amount_out: float,
-                 local_balance: int, capacity:int) -> float:
+def delta_demand(
+    params: dict,
+    time_interval: float,
+    amount_out: float,
+    local_balance: int,
+    capacity: int,
+) -> float:
     """Calculates a change factor for a channel by taking into account
     the amount transacted in a time interval compared to a target rate.
 
@@ -72,15 +77,16 @@ def delta_demand(params: dict, time_interval: float, amount_out: float,
     :param capacity: capacity in sat
     :return: demand adjustment factor"""
     r = amount_out / time_interval
-    r_t = params['r_t']
+    r_t = params["r_t"]
 
     logger.info(
         f"    Outward forwarded amount: {amount_out:6.0f} "
-        f"(rate {r:5.0f} / target rate {r_t:5.0f})")
+        f"(rate {r:5.0f} / target rate {r_t:5.0f})"
+    )
 
-    m = params['delta_min_dn']
+    m = params["delta_min_dn"]
 
-    c = 1. + m * (r / r_t - 1.)
+    c = 1.0 + m * (r / r_t - 1.0)
 
     mc = delta_min(params, local_balance, capacity)
 
@@ -88,8 +94,8 @@ def delta_demand(params: dict, time_interval: float, amount_out: float,
     if c < mc:
         return mc
     # cap from above
-    elif c > params['delta_max']:
-        return params['delta_max']
+    elif c > params["delta_max"]:
+        return params["delta_max"]
     else:
         return c
 
@@ -97,8 +103,9 @@ def delta_demand(params: dict, time_interval: float, amount_out: float,
 class FeeSetter(object):
     """Class for fee optimization."""
 
-    def __init__(self, node: 'LndNode', from_days_ago=7,
-                 parameters: Optional[dict] = None):
+    def __init__(
+        self, node: "LndNode", from_days_ago=7, parameters: Optional[dict] = None
+    ):
         """
         :param node: node instance
         :param from_days_ago: forwarding history is taken over the past
@@ -108,7 +115,7 @@ class FeeSetter(object):
         # by default, channel fees are updated, not initialized
         self.node = node
 
-        self.history_path = os.path.join(settings.home_dir, 'fee_history.log')
+        self.history_path = os.path.join(settings.home_dir, "fee_history.log")
 
         if parameters is None:
             self.params = optimization_parameters
@@ -125,12 +132,14 @@ class FeeSetter(object):
         self.time_start = self.time_end - from_days_ago * 24 * 60 * 60
         self.time_interval_days = from_days_ago
         self.forwarding_analyzer.initialize_forwarding_data(
-            self.time_start, self.time_end)
+            self.time_start, self.time_end
+        )
 
         # get channel info
         self.channels = self.node.get_all_channels()
-        self.channels_forwarding_stats = \
+        self.channels_forwarding_stats = (
             self.forwarding_analyzer.get_forwarding_statistics_channels()
+        )
 
     def set_fees(self, init=False, reckless=False) -> List[dict]:
         """Sets channel fee policies considering different metrics like
@@ -164,12 +173,14 @@ class FeeSetter(object):
         :return: (new channel policies, fee update statistics)"""
         logger.info("Determining new channel policies based on demand.")
         logger.info(
-            "Every channel will have a base fee of %d msat and cltv "
-            "of %d.", self.params['min_base_fee'], self.params['cltv'])
+            "Every channel will have a base fee of %d msat and cltv " "of %d.",
+            self.params["min_base_fee"],
+            self.params["cltv"],
+        )
         channel_fee_policies = {}
 
         try:
-            ignored_channels = self.node.config.items('excluded-channels-fee-opt')
+            ignored_channels = self.node.config.items("excluded-channels-fee-opt")
             ignored_channels = {int(c) for c, _ in ignored_channels}
         except NoSectionError:
             ignored_channels = set()
@@ -179,8 +190,10 @@ class FeeSetter(object):
         # loop over channel peers
         for pk, cs in self.node.pubkey_to_channel_map().items():
             ignore_peer = bool(set(cs).intersection(ignored_channels))
-            logger.info(f">>> Fee optimization for node {pk} "
-                        f"({self.node.network.node_alias(pk)}):")
+            logger.info(
+                f">>> Fee optimization for node {pk} "
+                f"({self.node.network.node_alias(pk)}):"
+            )
             # loop over channels with peer
             peer_capacity = 0
             peer_local_balance = 0
@@ -193,35 +206,32 @@ class FeeSetter(object):
             for channel_id in cs:
                 # collect channel info and stats
                 channel_data = self.channels[channel_id]
-                channel_stats = self.channels_forwarding_stats.get(
-                    channel_id,
-                    None
-                )
+                channel_stats = self.channels_forwarding_stats.get(channel_id, None)
 
                 if channel_stats is None:
                     number_forwardings_out = 0
                     total_forwarding_out = 0
                 else:
-                    number_forwardings_out = channel_stats[
-                        'number_forwardings_out']
-                    total_forwarding_out = channel_stats[
-                        'total_forwarding_out']
+                    number_forwardings_out = channel_stats["number_forwardings_out"]
+                    total_forwarding_out = channel_stats["total_forwarding_out"]
 
-                peer_capacity += channel_data['capacity']
-                peer_local_balance += channel_data['local_balance']
+                peer_capacity += channel_data["capacity"]
+                peer_local_balance += channel_data["local_balance"]
                 peer_number_forwardings_out += number_forwardings_out
                 peer_total_forwarding_out += total_forwarding_out
 
-                cumul_fee_rate += \
-                    self.channel_fee_policies[
-                        channel_data['channel_point']]['fee_rate']
-                cumul_base_fee += \
-                    self.channel_fee_policies[
-                        channel_data['channel_point']]['base_fee_msat']
+                cumul_fee_rate += self.channel_fee_policies[
+                    channel_data["channel_point"]
+                ]["fee_rate"]
+                cumul_base_fee += self.channel_fee_policies[
+                    channel_data["channel_point"]
+                ]["base_fee_msat"]
 
-            logger.info(f"    Channels with peer: {len(cs)}, "
-                        f"total capacity: {peer_capacity}, "
-                        f"total local balance: {peer_local_balance}")
+            logger.info(
+                f"    Channels with peer: {len(cs)}, "
+                f"total capacity: {peer_capacity}, "
+                f"total local balance: {peer_local_balance}"
+            )
 
             # calculate average base fee and fee rate
             base_fee_msat = int(cumul_base_fee / len(cs))
@@ -232,7 +242,8 @@ class FeeSetter(object):
                 self.params,
                 self.time_interval_days,
                 peer_total_forwarding_out,
-                peer_local_balance, peer_capacity
+                peer_local_balance,
+                peer_capacity,
             )
 
             # round down to 6 digits, as this is the expected data for
@@ -241,44 +252,50 @@ class FeeSetter(object):
 
             # if the fee rate is too low, cap it, as we don't want to
             # necessarily have too low fees, limit also from top
-            fee_rate_new = max(self.params['min_fee_rate'], fee_rate_new)
+            fee_rate_new = max(self.params["min_fee_rate"], fee_rate_new)
 
             # if the fee rate is too high, cap it, as we don't want to
             # loose channels due to other parties thinking we are too greedy
-            fee_rate_new = min(self.params['max_fee_rate'], fee_rate_new)
+            fee_rate_new = min(self.params["max_fee_rate"], fee_rate_new)
 
             # if we initialize the fee optimization, we want to start with
             # reasonable starting values
             if init:
-                fee_rate_new = self.params['max_fee_rate'] / 2
+                fee_rate_new = self.params["max_fee_rate"] / 2
 
             # BASE FEES
-            factor_base_fee = self.factor_demand_base_fee(
-                peer_number_forwardings_out)
+            factor_base_fee = self.factor_demand_base_fee(peer_number_forwardings_out)
             base_fee_msat_new = base_fee_msat * factor_base_fee
             if init:
-                base_fee_msat_new = self.params['min_base_fee']
+                base_fee_msat_new = self.params["min_base_fee"]
             else:
                 # limit from below
                 base_fee_msat_new = int(
-                    max(self.params['min_base_fee'], base_fee_msat_new))
+                    max(self.params["min_base_fee"], base_fee_msat_new)
+                )
                 # limit from above
                 base_fee_msat_new = int(
-                    min(self.params['max_base_fee'], base_fee_msat_new))
+                    min(self.params["max_base_fee"], base_fee_msat_new)
+                )
 
-            logger.info("    Fee rate change: %1.6f -> %1.6f (factor %1.3f)",
-                        fee_rate, fee_rate_new, factor_demand)
+            logger.info(
+                "    Fee rate change: %1.6f -> %1.6f (factor %1.3f)",
+                fee_rate,
+                fee_rate_new,
+                factor_demand,
+            )
 
-            logger.info("    Base fee change: %4d -> %4d (factor %1.3f)",
-                        base_fee_msat, base_fee_msat_new, factor_base_fee)
+            logger.info(
+                "    Base fee change: %4d -> %4d (factor %1.3f)",
+                base_fee_msat,
+                base_fee_msat_new,
+                factor_base_fee,
+            )
 
             # second loop through channels
             for channel_id in cs:
                 channel_data = self.channels[channel_id]
-                channel_stats = self.channels_forwarding_stats.get(
-                    channel_id,
-                    None
-                )
+                channel_stats = self.channels_forwarding_stats.get(channel_id, None)
                 if channel_stats is None:
                     flow = 0
                     fees_sat = 0
@@ -287,56 +304,65 @@ class FeeSetter(object):
                     number_forwardings = 0
                     number_forwardings_out = 0
                 else:
-                    flow = channel_stats['flow_direction']
-                    fees_sat = channel_stats['fees_total'] / 1000
-                    total_forwarding_in = channel_stats['total_forwarding_in']
-                    total_forwarding_out = channel_stats[
-                        'total_forwarding_out']
-                    number_forwardings = channel_stats['number_forwardings']
-                    number_forwardings_out = channel_stats[
-                        'number_forwardings_out']
+                    flow = channel_stats["flow_direction"]
+                    fees_sat = channel_stats["fees_total"] / 1000
+                    total_forwarding_in = channel_stats["total_forwarding_in"]
+                    total_forwarding_out = channel_stats["total_forwarding_out"]
+                    number_forwardings = channel_stats["number_forwardings"]
+                    number_forwardings_out = channel_stats["number_forwardings_out"]
 
-                lb = channel_data['local_balance']
-                ub = channel_data['unbalancedness']
-                capacity = channel_data['capacity']
+                lb = channel_data["local_balance"]
+                ub = channel_data["unbalancedness"]
+                capacity = channel_data["capacity"]
 
                 logger.info("  > Statistics for channel %s:", channel_id)
                 logger.info(
                     "    ub: %0.2f, flow: %0.2f, fees: %1.3f sat, "
                     "cap: %d sat, lb: %d sat, nfwd: %d, in: %d sat, "
-                    "out: %d sat.", ub, flow, fees_sat, capacity, lb,
-                    number_forwardings, total_forwarding_in,
-                    total_forwarding_out)
+                    "out: %d sat.",
+                    ub,
+                    flow,
+                    fees_sat,
+                    capacity,
+                    lb,
+                    number_forwardings,
+                    total_forwarding_in,
+                    total_forwarding_out,
+                )
 
-                stats.append({
-                    'date': self.time_end,
-                    'channelid': channel_id,
-                    'total_in': total_forwarding_in,
-                    'total_out': total_forwarding_out,
-                    'lb': lb,
-                    'ub': ub,
-                    'flow': flow,
-                    'fees': fees_sat,
-                    'cap': capacity,
-                    'fdem': factor_demand,
-                    'fr': self.channel_fee_policies[
-                        channel_data['channel_point']]['fee_rate'],
-                    'frn': fee_rate_new,
-                    'nfwd': number_forwardings,
-                    'nfwdo': number_forwardings_out,
-                    'fbase': factor_base_fee,
-                    'bf': self.channel_fee_policies[
-                        channel_data['channel_point']]['base_fee_msat'],
-                    'bfn': base_fee_msat_new,
-                })
+                stats.append(
+                    {
+                        "date": self.time_end,
+                        "channelid": channel_id,
+                        "total_in": total_forwarding_in,
+                        "total_out": total_forwarding_out,
+                        "lb": lb,
+                        "ub": ub,
+                        "flow": flow,
+                        "fees": fees_sat,
+                        "cap": capacity,
+                        "fdem": factor_demand,
+                        "fr": self.channel_fee_policies[channel_data["channel_point"]][
+                            "fee_rate"
+                        ],
+                        "frn": fee_rate_new,
+                        "nfwd": number_forwardings,
+                        "nfwdo": number_forwardings_out,
+                        "fbase": factor_base_fee,
+                        "bf": self.channel_fee_policies[channel_data["channel_point"]][
+                            "base_fee_msat"
+                        ],
+                        "bfn": base_fee_msat_new,
+                    }
+                )
 
                 if ignore_peer:
                     logger.info(f"    Ignore channel {channel_id} due to config file.")
                 else:
-                    channel_fee_policies[channel_data['channel_point']] = {
-                        'base_fee_msat': base_fee_msat_new,
-                        'fee_rate': fee_rate_new,
-                        'cltv': self.params['cltv'],
+                    channel_fee_policies[channel_data["channel_point"]] = {
+                        "base_fee_msat": base_fee_msat_new,
+                        "fee_rate": fee_rate_new,
+                        "cltv": self.params["cltv"],
                     }
             logger.info("")
         return channel_fee_policies, stats
@@ -348,15 +374,17 @@ class FeeSetter(object):
 
         :param num_fwd_out: number of outward forwardings
         :return: [1-c_max, 1+c_max]"""
-        logger.info(
-            "    Number of outward forwardings: %6.0f", num_fwd_out)
+        logger.info("    Number of outward forwardings: %6.0f", num_fwd_out)
 
         n = num_fwd_out / self.time_interval_days
-        delta = 1 + optimization_parameters['delta_b'] * (
-                n / optimization_parameters['n_t'] - 1)
+        delta = 1 + optimization_parameters["delta_b"] * (
+            n / optimization_parameters["n_t"] - 1
+        )
 
-        delta = max(1 - optimization_parameters['delta_b_min'],
-                    min(delta, 1 + optimization_parameters['delta_b_max']))
+        delta = max(
+            1 - optimization_parameters["delta_b_min"],
+            min(delta, 1 + optimization_parameters["delta_b_max"]),
+        )
         return delta
 
     def append_to_history(self, stats: List[dict]):
@@ -364,28 +392,28 @@ class FeeSetter(object):
 
         :param stats: fee statistics"""
         logger.debug("Saving fee setting stats to fee history.")
-        with open(self.history_path, 'a') as f:
+        with open(self.history_path, "a") as f:
             json.dump(stats, f)
-            f.write('\n')
+            f.write("\n")
 
     def read_history(self) -> List[dict]:
         """read_history is a function for unpickling the fee setting history.
 
         :return: list of fee setting statistics
         :rtype: list[dict]"""
-        with open(self.history_path, 'r') as f:
+        with open(self.history_path, "r") as f:
             history = []
             for i, line in enumerate(f):
                 history.append(json.loads(line))
         return history
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from lndmanage.lib.node import LndNode
     import logging.config
 
     logging.config.dictConfig(settings.logger_config)
 
-    nd = LndNode('/home/user/.lndmanage/config.ini')
+    nd = LndNode("/home/user/.lndmanage/config.ini")
     fee_setter = FeeSetter(nd)
     fee_setter.set_fees()

--- a/lndmanage/lib/fee_setting.py
+++ b/lndmanage/lib/fee_setting.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 optimization_parameters = {
-    'cltv': 14,  # blocks
+    'cltv': 40,  # blocks
     'min_base_fee': 0,  # msat
     'max_base_fee': 5000,  # msat
     'min_fee_rate': 0.000005,

--- a/lndmanage/lib/forwardings.py
+++ b/lndmanage/lib/forwardings.py
@@ -113,6 +113,7 @@ class ForwardingAnalyzer(object):
                 'median_forwarding_in': c.median_forwarding_in(),
                 'median_forwarding_out': c.median_forwarding_out(),
                 'number_forwardings': c.number_forwardings(),
+                'number_forwardings_out': c.number_forwardings_out(),
                 'largest_forwarding_amount_in':
                     c.largest_forwarding_amount_in(),
                 'largest_forwarding_amount_out':
@@ -180,7 +181,7 @@ class ForwardingAnalyzer(object):
             tot_in = n['total_forwarding_in']
             tot_out = n['total_forwarding_out']
             node_statistics[k]['flow_direction'] = \
-                -((float(tot_in) / (tot_in + tot_out)) - 0.5) / 0.5
+                (- tot_in + tot_out) / (tot_in + tot_out)
 
         sorted_dict = OrderedDict(
             sorted(node_statistics.items(), key=lambda x: -x[1][sort_by]))
@@ -525,11 +526,16 @@ class ChannelStatistics(object):
     def flow_direction(self):
         total_in = self.total_forwarding_in()
         total_out = self.total_forwarding_out()
-        return -((float(total_in) / (total_in + total_out)) - 0.5) / 0.5
+        try:
+            return (- total_in + total_out) / (total_in + total_out)
+        except ZeroDivisionError:
+            return 0
 
     def number_forwardings(self):
         return len(self.inward_forwardings) + len(self.outward_forwardings)
 
+    def number_forwardings_out(self):
+        return len(self.outward_forwardings)
 
 def get_forwarding_statistics_channels(node, time_interval_start,
                                        time_interval_end):

--- a/lndmanage/lib/listchannels.py
+++ b/lndmanage/lib/listchannels.py
@@ -455,9 +455,8 @@ class ListChannels(object):
         channel_point_mapping = {k: v['channel_point'].split(':')[0]
                                  for k, v in channels.items()}
         # only read annotations if config file is given
-        if self.node.config_file:
-            config = settings.read_config(self.node.config_file)
-            annotations = config['annotations']
+        if self.node.config:
+            annotations = self.node.config['annotations']
         else:
             annotations = {}
         channel_annotations_funding_id = {}

--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -65,23 +65,22 @@ class Node(object):
 
 
 class LndNode(Node):
-    """
-    Implements an interface to an lnd node.
-    """
-    def __init__(self, config_file=None, lnd_home=None, lnd_host=None,
-                 regtest=False):
+    """Implements the node interface for LND."""
+    def __init__(self, config_file: Optional[str] = None,
+                 lnd_home: Optional[str] = None,
+                 lnd_host: Optional[str] = None, regtest=False):
         """
         :param config_file: path to the config file
-        :type config_file: str
         :param lnd_home: path to lnd home folder
-        :type lnd_home: str
         :param lnd_host: lnd host of format "127.0.0.1:9735"
-        :type lnd_host: str
         :param regtest: if the node is representing a regtest node
-        :type regtest: bool
         """
         super().__init__()
-        self.config_file = config_file
+        if config_file:
+            self.config_file = config_file
+            self.config = settings.read_config(self.config_file)
+        else:
+            self.config = None
         self.lnd_home = lnd_home
         self.lnd_host = lnd_host
         self.regtest = regtest
@@ -123,11 +122,10 @@ class LndNode(Node):
                     'if lnd_home is given, lnd_host must be given also')
             lnd_host = self.lnd_host
         else:
-            config = settings.read_config(self.config_file)
-            cert_file = os.path.expanduser(config['network']['tls_cert_file'])
+            cert_file = os.path.expanduser(self.config['network']['tls_cert_file'])
             macaroon_file = \
-                os.path.expanduser(config['network']['admin_macaroon_file'])
-            lnd_host = config['network']['lnd_grpc_host']
+                os.path.expanduser(self.config['network']['admin_macaroon_file'])
+            lnd_host = self.config['network']['lnd_grpc_host']
 
         cert = None
         try:

--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -1,10 +1,10 @@
 import binascii
 import codecs
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import datetime
 import os
 import time
-from typing import Dict, List, Tuple, TYPE_CHECKING, Optional
+from typing import List, TYPE_CHECKING, Optional
 
 import grpc
 from grpc._channel import _Rendezvous
@@ -464,6 +464,42 @@ class LndNode(Node):
             if abs(c['unbalancedness']) >= unbalancedness_greater_than
         }
         return unbalanced_channels
+
+    def get_channel_fee_policies(self):
+        """
+        Gets the node's channel fee policies for every open channel.
+        :return: dict
+        """
+        feereport = self._rpc.FeeReport(lnd.FeeReportRequest())
+        channels = {}
+        for fee in feereport.channel_fees:
+            channels[fee.channel_point] = {
+                'base_fee_msat': fee.base_fee_msat,
+                'fee_per_mil': fee.fee_per_mil,
+                'fee_rate': fee.fee_rate,
+            }
+        return channels
+
+    def set_channel_fee_policies(self, channels: dict):
+        """
+        Sets the node's channel fee policy for every channel.
+        :param channels: channel point -> fee policy
+        """
+
+        for channel_point, channel_fee_policy in channels.items():
+            funding_txid, output_index = channel_point.split(':')
+            output_index = int(output_index)
+
+            channel_point = lnd.ChannelPoint(
+                funding_txid_str=funding_txid, output_index=output_index)
+
+            update_request = lnd.PolicyUpdateRequest(
+                chan_point=channel_point,
+                base_fee_msat=channel_fee_policy['base_fee_msat'],
+                fee_rate=channel_fee_policy['fee_rate'],
+                time_lock_delta=channel_fee_policy['cltv'],
+            )
+            self._rpc.UpdateChannelPolicy(request=update_request)
 
     @staticmethod
     def timestamp_from_now(offset_days=0):
@@ -932,7 +968,19 @@ class LndNode(Node):
                 raise ConnectionRefusedError
         return succeeded_nodes
 
+    def pubkey_to_channel_map(self):
+        """
+        Determines a dict with node pubkeys this node has a channel with, which
+        maps to a list of all the channels with the node.
 
-if __name__ == '__main__':
-    node = LndNode()
-    print(node.get_closed_channels().keys())
+        :return: dictionary of pubkeys with list of channels as value
+        :rtype: dict[list]
+        """
+        channels = self.get_all_channels()
+
+        node_to_channel_map = defaultdict(list)
+
+        for c, cv in channels.items():
+            node_to_channel_map[cv['remote_pubkey']].append(c)
+
+        return node_to_channel_map

--- a/lndmanage/templates/config_sample.ini
+++ b/lndmanage/templates/config_sample.ini
@@ -15,3 +15,8 @@ loglevel = INFO
 # Examples:
 # mavh27t03e0hcp3ni7wcj3avhln8o5lleno0noaiiwlivkp0yk3gwfx2bskjx70v0u = node has a high capacity per channel
 # 635263839283742663 = transaction flow out
+
+[excluded-channels-fee-opt]
+# channels which are excluded from the fee optimization via the update-fees
+# command can be listed here by their channel ids, e.g.,
+# 635263839283742663=ignore

--- a/test/test_fee_setting.py
+++ b/test/test_fee_setting.py
@@ -1,0 +1,88 @@
+from unittest import TestCase
+import logging
+import sys
+
+from lndmanage.lib.fee_setting import delta_demand, delta_min, optimization_parameters
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+class TestFeeSetter(TestCase):
+    def test_delta_min(self):
+        cap = 2000000
+        # maximal upward adjustment for empty local balance
+        self.assertAlmostEqual(
+            1 + optimization_parameters["delta_min_up"],
+            delta_min(optimization_parameters, local_balance=0, capacity=cap),
+        )
+        # no adjustment if local balance is balance reserve
+        self.assertAlmostEqual(
+            1,
+            delta_min(
+                optimization_parameters,
+                local_balance=optimization_parameters["local_balance_reserve"],
+                capacity=cap,
+            ),
+        )
+        # maximal downward adjustment for full local balance
+        self.assertAlmostEqual(
+            1 - optimization_parameters["delta_min_dn"],
+            delta_min(optimization_parameters, local_balance=cap, capacity=cap),
+        )
+
+    def test_factor_demand_fee_rate(self):
+        cap = 2000000
+        interval_days = 7
+        # maximal downward adjustment for full local balance and no demand
+        self.assertAlmostEqual(
+            1 - optimization_parameters["delta_min_dn"],
+            delta_demand(
+                optimization_parameters,
+                time_interval=interval_days,
+                amount_out=0,
+                local_balance=cap,
+                capacity=cap,
+            ),
+            places=6,
+        )
+
+        # maximal upward adjustment in the case of empty local balance and no demand
+        self.assertAlmostEqual(
+            1 + optimization_parameters["delta_min_up"],
+            delta_demand(
+                optimization_parameters,
+                time_interval=interval_days,
+                amount_out=0,
+                local_balance=0,
+                capacity=cap,
+            ),
+            places=6,
+        )
+
+        # optimal amount: no change
+        self.assertAlmostEqual(
+            1,
+            delta_demand(
+                optimization_parameters,
+                time_interval=interval_days,
+                amount_out=optimization_parameters["r_t"] * interval_days,
+                local_balance=cap,
+                capacity=cap,
+            ),
+            places=6,
+        )
+
+        # maximal demand: highest change
+        self.assertAlmostEqual(
+            optimization_parameters["delta_max"],
+            delta_demand(
+                optimization_parameters,
+                time_interval=interval_days,
+                amount_out=1000000,
+                local_balance=cap,
+                capacity=cap,
+            ),
+            places=6,
+        )


### PR DESCRIPTION
Add `update-fee` command, which is meant to be invoked periodically (~every week) for channel fee optimization purposes.

The command will adjust the fee rates and optionally the base fees (they are set to zero by default) after user consent, such that the demand for liquidity of a channel is taken into account. A liquidity reserve is kept for excess demand with a fee premium.

The command aims for a weekly throughput of 100k sat per channel (configurable). The weekly throughput will be optimized for maximal fees in future work. See the readme changes for further details.

Todo:
- [x] add description in readme
- [x] change type annotations
- [x] make global throughput configurable
- [x] exempt channels from optimization via config file
- [x] comment on initial fee setting