### PR TITLE
rebalancer: Fix bug where budget is ignored, remove DEFAULT_MAX_FEE_RATE

### DIFF
--- a/lndmanage/lib/rebalance.py
+++ b/lndmanage/lib/rebalance.py
@@ -479,8 +479,8 @@ class Rebalancer(object):
 
         net_change = abs(initial_local_balance_change)
         max_effective_fee_rate = min(
-            max_effective_fee_rate if max_effective_fee_rate else Decimal(1),
-            budget_sat / net_change if budget_sat else Decimal(1)
+            max_effective_fee_rate if max_effective_fee_rate is not None else Decimal(1),
+            budget_sat / net_change if budget_sat is not None else Decimal(1)
         )
 
         logger.info(

--- a/lndmanage/lndmanage.py
+++ b/lndmanage/lndmanage.py
@@ -21,7 +21,7 @@ from lndmanage.lib.listings import ListChannels, ListPeers
 from lndmanage.lib.lncli import Lncli
 from lndmanage.lib.node import LndNode
 from lndmanage.lib.openchannels import ChannelOpener
-from lndmanage.lib.rebalance import Rebalancer, DEFAULT_MAX_FEE_RATE, DEFAULT_AMOUNT_SAT
+from lndmanage.lib.rebalance import Rebalancer, DEFAULT_AMOUNT_SAT
 from lndmanage.lib.recommend_nodes import RecommendNodes
 from lndmanage.lib.report import Report
 
@@ -171,7 +171,7 @@ class Parser(object):
             help='Specifies the increase in local balance in sat. The amount can be'
                  f'negative to decrease the local balance. Default: {DEFAULT_AMOUNT_SAT} sat.')
         self.parser_rebalance.add_argument(
-            '--max-fee-rate', type=range_limited_float_type, default=DEFAULT_MAX_FEE_RATE,
+            '--max-fee-rate', type=range_limited_float_type, default=None,
             help='Sets the maximal effective fee rate to be paid.'
                  ' The effective fee rate is defined by '
                  '(base_fee + amt * fee_rate) / amt.')

--- a/test/test_rebalance.py
+++ b/test/test_rebalance.py
@@ -275,7 +275,8 @@ class TestIlliquidRebalance(RebalanceTest):
                 target=Decimal('-0.05'),
                 amount_sat=None,
                 allow_uneconomic=True,
-                places=1
+                max_effective_fee_rate=Decimal('61E-7'),
+                places=1,
             )
         )
         self.assertAlmostEqual(2000, fees_msat, places=-3)


### PR DESCRIPTION
This fixes a bug where the rebalancer takes the max of the two budget options, instead of the min.
Also removes the default fee rate, since it's cumbersome to keep aligning both when one just wants to set the budget.

Also cleans up a bit; since the budget and the fee rate are correlated, it's unnecessary to keep state for both.