### PR TITLE
Pathfinding: pair-based liquidity hints and sync from mission control

### DIFF
--- a/lndmanage/lib/data_types.py
+++ b/lndmanage/lib/data_types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass, field
+from typing import Tuple
 
 
 class AddressType(Enum):
@@ -46,3 +47,15 @@ class NodeProperties:
     remote_base_fees: list
     remote_balances: list
     sent_received_per_week: int
+
+
+class NodePair(tuple):
+    """Represents a node pair mapped to a fixed order."""
+
+    def __new__(cls, keys: Tuple[str, str]):
+        if keys[0].casefold() < keys[1].casefold():
+            seq = (keys[0], keys[1])
+        else:
+            seq = (keys[1], keys[0])
+
+        return super().__new__(cls, seq)

--- a/lndmanage/lib/data_types.py
+++ b/lndmanage/lib/data_types.py
@@ -59,3 +59,11 @@ class NodePair(tuple):
             seq = (keys[1], keys[0])
 
         return super().__new__(cls, seq)
+
+
+class NodeID(str):
+    pass
+
+
+class ShortChannelID(int):
+    pass

--- a/lndmanage/lib/liquidityhints.py
+++ b/lndmanage/lib/liquidityhints.py
@@ -111,9 +111,6 @@ class LiquidityHint:
         # sanity check
         if self._can_send_forward > self._cannot_send_forward:
             self._can_send_forward = AmountHistory()
-        # if we can't send over the channel, we should be able to send in the
-        # reverse direction
-        self.can_send_backward = new_amount_history
 
     @property
     def cannot_send_backward(self) -> AmountHistory:
@@ -130,7 +127,6 @@ class LiquidityHint:
         # sanity check
         if self._can_send_backward > self._cannot_send_backward:
             self._can_send_backward = AmountHistory()
-        self.can_send_forward = new_amount_history
 
     def can_send(self, is_forward_direction: bool) -> AmountHistory:
         # make info invalid after some time?

--- a/lndmanage/lib/liquidityhints.py
+++ b/lndmanage/lib/liquidityhints.py
@@ -23,20 +23,20 @@ TIME_NODE_IS_SLOW_SEC = 5  # the time a node is viewed as slow
 
 @dataclass
 class AmountHistory:
-    amount: int = None  # msat
+    amount_msat: int = None  # msat
     timestamp: int = None
 
     def __bool__(self):
-        return self.amount is not None and self.timestamp is not None
+        return self.amount_msat is not None and self.timestamp is not None
 
     def __gt__(self, other):
-        return self and other and self.amount > other.amount
+        return self and other and self.amount_msat > other.amount_msat
 
     def __lt__(self, other):
-        return self and other and self.amount < other.amount
+        return self and other and self.amount_msat < other.amount_msat
 
     def __str__(self):
-        return str(self.amount)
+        return str(self.amount_msat)
 
 
 class LiquidityHint:
@@ -303,8 +303,8 @@ class LiquidityHintMgr:
         can_send = None
         cannot_send = None
         if hint:
-            can_send = hint.can_send(node_from > node_to).amount
-            cannot_send = hint.cannot_send(node_from > node_to).amount
+            can_send = hint.can_send(node_from > node_to).amount_msat
+            cannot_send = hint.cannot_send(node_from > node_to).amount_msat
 
         # if the hint doesn't help us, we set defaults
         if can_send is None:

--- a/lndmanage/lib/liquidityhints.py
+++ b/lndmanage/lib/liquidityhints.py
@@ -53,7 +53,6 @@ class LiquidityHint:
         self._can_send_backward = AmountHistory()
         self._cannot_send_backward = AmountHistory()
         self.blacklist_timestamp = 0
-        self.hint_timestamp = 0
         self._inflight_htlcs_forward = 0
         self._inflight_htlcs_backward = 0
 
@@ -364,7 +363,10 @@ class LiquidityHintMgr:
 
     def reset_liquidity_hints(self):
         for k, v in self._liquidity_hints.items():
-            v.hint_timestamp = 0
+            v._can_send_forward = AmountHistory()
+            v._can_send_backward = AmountHistory()
+            v._cannot_send_forward = AmountHistory()
+            v._cannot_send_backward = AmountHistory()
 
     def __repr__(self):
         string = "liquidity hints:\n"

--- a/lndmanage/lib/liquidityhints.py
+++ b/lndmanage/lib/liquidityhints.py
@@ -216,6 +216,7 @@ class LiquidityHintMgr:
         # badness hints have an exponential decay time of BADNESS_DECAY_SEC updated
         # every BADNESS_DECAY_ADJUSTMENT_SEC
         self._badness_timestamps: Dict[NodeID, float] = defaultdict(float)
+        self.mc_sync_timestamp: int = 0
 
     @property
     def now(self):
@@ -382,6 +383,7 @@ class LiquidityHintMgr:
         return string
 
     def extend_with_mission_control(self, mc_pairs):
+        logger.info("> Syncing mission control data.")
         for pair in mc_pairs:
             node_from = pair.node_from.hex()
             node_to = pair.node_to.hex()
@@ -397,3 +399,4 @@ class LiquidityHintMgr:
                     node_from, node_to, pair.history.fail_amt_msat,
                     pair.history.fail_time,
                 )
+        self.mc_sync_timestamp = int(time.time())

--- a/lndmanage/lib/liquidityhints.py
+++ b/lndmanage/lib/liquidityhints.py
@@ -5,6 +5,9 @@ from typing import Set, Dict
 from math import inf, log
 
 import logging
+
+from lib.data_types import NodeID, ShortChannelID
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -15,14 +18,6 @@ BADNESS_DECAY_SEC = 24 * 3600  # exponential decay time for badness
 TIME_EXPECTATION_ACCURACY = 0.2  # the relative error in estimating node reaction times
 TIME_PENALTY_RATE = 0.000_010  # the default penalty for reaction time
 TIME_NODE_IS_SLOW_SEC = 5  # the time a node is viewed as slow
-
-
-class ShortChannelID(int):
-    pass
-
-
-class NodeID(str):
-    pass
 
 
 class LiquidityHint:

--- a/lndmanage/lib/liquidityhints.py
+++ b/lndmanage/lib/liquidityhints.py
@@ -228,14 +228,14 @@ class LiquidityHintMgr:
         node_pair = NodePair((node_from, node_to))
         logger.debug(f"    report: can send {amount_msat // 1000} sat over channel {node_pair}")
         hint = self._get_hint(node_pair)
-        hint.update_can_send(node_from < node_to, amount_msat)
+        hint.update_can_send(node_from > node_to, amount_msat)
         self._could_route[node_from] += 1
 
     def update_cannot_send(self, node_from: NodeID, node_to: NodeID, amount: int):
         node_pair = NodePair((node_from, node_to))
         logger.debug(f"    report: cannot send {amount // 1000} sat over channel {node_pair}")
         hint = self._get_hint(node_pair)
-        hint.update_cannot_send(node_from < node_to, amount)
+        hint.update_cannot_send(node_from > node_to, amount)
         self._could_not_route[node_from] += 1
 
     def update_badness_hint(self, node: NodeID, badness: float):
@@ -260,12 +260,12 @@ class LiquidityHintMgr:
     def add_htlc(self, node_from: NodeID, node_to: NodeID):
         node_pair = NodePair((node_from, node_to))
         hint = self._get_hint(node_pair)
-        hint.add_htlc(node_from < node_to)
+        hint.add_htlc(node_from > node_to)
 
     def remove_htlc(self, node_from: NodeID, node_to: NodeID):
         node_pair = NodePair((node_from, node_to))
         hint = self._get_hint(node_pair)
-        hint.remove_htlc(node_from < node_to)
+        hint.remove_htlc(node_from > node_to)
 
     def penalty(self, node_from: NodeID, node_to: NodeID, capacity: int,
                 amount_msat: int, fee_rate_milli_msat: int) -> float:
@@ -300,8 +300,8 @@ class LiquidityHintMgr:
         can_send = None
         cannot_send = None
         if hint:
-            can_send = hint.can_send(node_from < node_to).amount
-            cannot_send = hint.cannot_send(node_from < node_to).amount
+            can_send = hint.can_send(node_from > node_to).amount
+            cannot_send = hint.cannot_send(node_from > node_to).amount
 
         # if the hint doesn't help us, we set defaults
         if can_send is None:

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -62,7 +62,7 @@ class Network:
             timestamp_graph = 0  # set very old timestamp
 
         if timestamp_graph < time.time() - settings.CACHING_RETENTION_MINUTES * 60:  # old graph in file
-            logger.info(f"Cached graph is too old. Fetching new one.")
+            logger.info(f"> Cached graph is too old. Fetching new one.")
             self.set_graph_edges_pairs()
             with open(cache_graph_filename, 'wb') as file:
                 pickle.dump(self.graph, file, pickle.HIGHEST_PROTOCOL)
@@ -84,7 +84,7 @@ class Network:
             with open(cache_hints_filename, 'rb') as file:
                 self.liquidity_hints = pickle.load(file)
                 num_badness_hints = len([f for f in self.liquidity_hints._badness_hints.values() if f])
-            logger.info(f"> Loaded liquidty hints: {len(self.liquidity_hints._liquidity_hints)} hints, {num_badness_hints} badness hints.")
+            logger.info(f"> Loaded liquidity hints: {len(self.liquidity_hints._liquidity_hints)} hints, {num_badness_hints} badness hints.")
         except FileNotFoundError:
             self.liquidity_hints = LiquidityHintMgr(self.node.pub_key)
         except Exception as e:
@@ -94,6 +94,7 @@ class Network:
         if self.liquidity_hints.mc_sync_timestamp < time.time() - settings.CACHING_RETENTION_MINUTES * 60:
             mc_pairs = self.node.query_mc()
             self.liquidity_hints.extend_with_mission_control(mc_pairs)
+            logger.info(f"> Synced mission control data (imported {len(mc_pairs)} pairs).")
             self.save_liquidty_hints()
 
     @profiled

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -5,6 +5,7 @@ from typing import Dict, TYPE_CHECKING
 
 import networkx as nx
 
+from lndmanage.lib.data_types import NodePair
 from lndmanage.lib.utilities import profiled
 from lndmanage.lib.ln_utilities import convert_channel_id_to_short_channel_id
 from lndmanage.lib.liquidityhints import LiquidityHintMgr
@@ -120,6 +121,8 @@ class Network:
                 color=n.color)
 
         for e in raw_graph.edges:
+            node_pair = NodePair((e.node1_pub, e.node2_pub))
+
             policy1 = {
                 'time_lock_delta': e.node1_policy.time_lock_delta,
                 'fee_base_msat': e.node1_policy.fee_base_msat,
@@ -142,6 +145,7 @@ class Network:
             self.edges[e.channel_id] = {
                 'node1_pub': e.node1_pub,
                 'node2_pub': e.node2_pub,
+                'node_pair': node_pair,
                 'capacity': e.capacity,
                 'last_update': e.last_update,
                 'channel_id': e.channel_id,
@@ -156,6 +160,7 @@ class Network:
             self.graph.add_edge(
                 e.node1_pub,
                 e.node2_pub,
+                node_pair=node_pair,
                 channel_id=e.channel_id,
                 last_update=e.last_update,
                 capacity=e.capacity,

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -90,12 +90,15 @@ class Network:
         except Exception as e:
             logger.exception(e)
 
-        # we extend our information with data from mission control
-        if self.liquidity_hints.mc_sync_timestamp < time.time() - settings.CACHING_RETENTION_MINUTES * 60:
-            mc_pairs = self.node.query_mc()
-            self.liquidity_hints.extend_with_mission_control(mc_pairs)
-            logger.info(f"> Synced mission control data (imported {len(mc_pairs)} pairs).")
-            self.save_liquidty_hints()
+        try:
+            # we extend our information with data from mission control
+            if self.liquidity_hints.mc_sync_timestamp < time.time() - settings.CACHING_RETENTION_MINUTES * 60:
+                mc_pairs = self.node.query_mc()
+                self.liquidity_hints.extend_with_mission_control(mc_pairs)
+                logger.info(f"> Synced mission control data (imported {len(mc_pairs)} pairs).")
+                self.save_liquidty_hints()
+        except AttributeError:
+            raise Exception("Hints file to old, please delete cache folder.")
 
     @profiled
     def save_liquidty_hints(self):

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -90,6 +90,12 @@ class Network:
         except Exception as e:
             logger.exception(e)
 
+        # TODO: don't load if we loaded some time ago
+        # we extend our information with data from mission control
+        mc_pairs = self.node.query_mc()
+        self.liquidity_hints.extend_with_mission_control(mc_pairs)
+        self.save_liquidty_hints()
+
     @profiled
     def save_liquidty_hints(self):
         cache_hints_filename = make_cache_filename('liquidity_hints.gpickle')

--- a/lndmanage/lib/network.py
+++ b/lndmanage/lib/network.py
@@ -90,11 +90,11 @@ class Network:
         except Exception as e:
             logger.exception(e)
 
-        # TODO: don't load if we loaded some time ago
         # we extend our information with data from mission control
-        mc_pairs = self.node.query_mc()
-        self.liquidity_hints.extend_with_mission_control(mc_pairs)
-        self.save_liquidty_hints()
+        if self.liquidity_hints.mc_sync_timestamp < time.time() - settings.CACHING_RETENTION_MINUTES * 60:
+            mc_pairs = self.node.query_mc()
+            self.liquidity_hints.extend_with_mission_control(mc_pairs)
+            self.save_liquidty_hints()
 
     @profiled
     def save_liquidty_hints(self):

--- a/lndmanage/lib/node.py
+++ b/lndmanage/lib/node.py
@@ -1039,3 +1039,9 @@ class LndNode:
             node_to_channel_map[cv['remote_pubkey']].append(c)
 
         return node_to_channel_map
+
+    def query_mc(self):
+        resp = self._routerrpc.QueryMissionControl(
+            lndrouter.QueryMissionControlRequest()
+        )
+        return resp.pairs

--- a/lndmanage/lib/rebalance.py
+++ b/lndmanage/lib/rebalance.py
@@ -151,7 +151,9 @@ class Rebalancer(object):
                     self.node.network.liquidity_hints.update_elapsed_time(source_node, elapsed_time / success_path_length)
                     if failed_hop_index and hop == failed_hop_index:
                         break
-                    self.node.network.liquidity_hints.update_can_send(source_node, target_node, channel['chan_id'], amt_msat)
+                    self.node.network.liquidity_hints.update_can_send(
+                        source_node, target_node, amt_msat,
+                    )
 
                 # symmetrically penalize a route about the error source if it failed
                 if failed_hop_index:
@@ -206,7 +208,8 @@ class Rebalancer(object):
 
                     # report that channel could not route the amount to liquidity hints
                     self.node.network.liquidity_hints.update_cannot_send(
-                        failed_source, failed_target, failed_channel_id, amt_msat)
+                        failed_source, failed_target, amt_msat,
+                    )
 
                     # report all the previous hops that they could route the amount
                     report_success_up_to_failed_hop(failed_hop)

--- a/lndmanage/lib/routing.py
+++ b/lndmanage/lib/routing.py
@@ -1,5 +1,6 @@
-from typing import List, Dict, TYPE_CHECKING, Tuple
+from typing import List, Dict, TYPE_CHECKING
 
+from lndmanage.lib.data_types import NodePair
 from lndmanage.lib.exceptions import RouteWithTooSmallCapacity, NoRoute
 from lndmanage.lib.pathfinding import dijkstra
 from lndmanage import settings
@@ -74,10 +75,12 @@ class Route(object):
             forward_msat = amt_msat + sum(fees_msat_container[:ichannel])
             fees_msat_container.append(fees_msat)
 
+            node_pair = NodePair((channel_data['node1_pub'], channel_data['node2_pub']))
+            capacity = self.node.network.max_pair_capacity[node_pair]
             logger.info(f"      Fees: {fees_msat / 1000 if not hop == 1 else 0:3.3f} sat")
             logger.debug(f"      Fees container {fees_msat_container}")
             logger.debug(f"      Forward: {forward_msat / 1000:3.3f} sat")
-            logger.info(f"      Liquidity penalty: {self.node.network.liquidity_hints.penalty(node_from, node_to, channel_data, amt_msat, self.node.network.channel_rater.reference_fee_rate_milli_msat) / 1000: 3.3f} sat")
+            logger.info(f"      Liquidity penalty: {self.node.network.liquidity_hints.penalty(node_from, node_to, capacity, amt_msat, self.node.network.channel_rater.reference_fee_rate_milli_msat) / 1000: 3.3f} sat")
             logger.info(f"      Badness penalty: {self.node.network.liquidity_hints.badness_penalty(node_from, amt_msat) / 1000: 3.3f} sat")
             logger.info(f"      Time penalty: {self.node.network.liquidity_hints.time_penalty(node_from, amt_msat) / 1000: 3.3f} sat")
 

--- a/lndmanage/lndmanage.py
+++ b/lndmanage/lndmanage.py
@@ -635,7 +635,7 @@ async def _main():
         lndnode = LndNode(config_file=config_file)
         async with lndnode:
             if parser.lncli_path:
-                logger.info("Enabled lncli: using " + parser.lncli_path)
+                logger.info("> Enabled lncli: using " + parser.lncli_path)
 
             while True:
                 try:

--- a/test/test_liquidityhints.py
+++ b/test/test_liquidityhints.py
@@ -64,7 +64,7 @@ class LiquidityTest(TestCase):
         )
         # we conclude for the backward direction from the failure:
         self.assertEqual(
-            AmountHistory(amount=30000, timestamp=1),
+            AmountHistory(),
             hint.can_send("bb" > "aa"),
         )
         # we can't say anything about the amount that cannot be sent in the backward

--- a/test/test_liquidityhints.py
+++ b/test/test_liquidityhints.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+from unittest import TestCase, mock
+
+from lndmanage.lib.data_types import NodePair
+from lndmanage.lib.liquidityhints import LiquidityHintMgr, AmountHistory
+
+
+@dataclass
+class MCPairHistory:
+    fail_amt_msat: int
+    success_amt_msat: int
+    fail_time: int = 0
+    success_time: int = 0
+
+
+@dataclass
+class MCPair:
+    node_from: bytes
+    node_to: bytes
+    history: MCPairHistory
+
+
+class LiquidityTest(TestCase):
+
+    @mock.patch('time.time', mock.MagicMock(return_value=100))
+    def test_load_mission_control(self):
+        mgr = LiquidityHintMgr("pubkey")
+
+        pairs = [
+            # valid pair
+            MCPair(
+                node_from=bytes.fromhex("aa"),
+                node_to=bytes.fromhex("bb"),
+                history=MCPairHistory(
+                    success_amt_msat=10000,
+                    success_time=1,  # to be considered a valid hint
+                    fail_amt_msat=30000,
+                    fail_time=1,  # to be considered a valid hint
+                )
+            ),
+            # invalid pair (no timestamps)
+            MCPair(
+                node_from=bytes.fromhex("bb"),
+                node_to=bytes.fromhex("cc"),
+                history=MCPairHistory(
+                    fail_amt_msat=30000,
+                    success_amt_msat=10000,
+                )
+            )
+        ]
+        mgr.extend_with_mission_control(pairs)
+
+        node_pair = NodePair(("aa", "bb"))
+        hint = mgr._liquidity_hints.get(node_pair)
+        # hint from mc:
+        self.assertEqual(
+            AmountHistory(amount=10000, timestamp=1),
+            hint.can_send("aa" > "bb"),
+        )
+        # hint from mc:
+        self.assertEqual(
+            AmountHistory(amount=30000, timestamp=1),
+            hint.cannot_send("aa" > "bb"),
+        )
+        # we conclude for the backward direction from the failure:
+        self.assertEqual(
+            AmountHistory(amount=30000, timestamp=1),
+            hint.can_send("bb" > "aa"),
+        )
+        # we can't say anything about the amount that cannot be sent in the backward
+        # direction
+        self.assertEqual(
+            AmountHistory(),
+            hint.cannot_send("bb" > "aa"),
+        )
+
+        node_pair = NodePair(("bb", "cc"))
+        hint = mgr._liquidity_hints.get(node_pair)
+        self.assertIsNone(hint)

--- a/test/test_liquidityhints.py
+++ b/test/test_liquidityhints.py
@@ -54,12 +54,12 @@ class LiquidityTest(TestCase):
         hint = mgr._liquidity_hints.get(node_pair)
         # hint from mc:
         self.assertEqual(
-            AmountHistory(amount=10000, timestamp=1),
+            AmountHistory(amount_msat=10000, timestamp=1),
             hint.can_send("aa" > "bb"),
         )
         # hint from mc:
         self.assertEqual(
-            AmountHistory(amount=30000, timestamp=1),
+            AmountHistory(amount_msat=30000, timestamp=1),
             hint.cannot_send("aa" > "bb"),
         )
         # we conclude for the backward direction from the failure:

--- a/test/test_pathfinding.py
+++ b/test/test_pathfinding.py
@@ -27,6 +27,7 @@ def new_test_graph(graph: Dict):
         network.edges = {}
         # TODO: fix side effects of liquidity hints loading
         network.liquidity_hints = LiquidityHintMgr(MockNode.pub_key)
+        network.max_pair_capacity = {}
 
     # add nodes
     for node, node_definition in graph.items():
@@ -42,6 +43,7 @@ def new_test_graph(graph: Dict):
         for channel, channel_definition in node_definition['channels'].items():
             # create a dictionary for channel_id lookups
             to_node = channel_definition['to']
+            node_pair = NodePair((node, to_node))
             network.edges[channel] = {
                 'node1_pub': node,
                 'node2_pub': to_node,
@@ -68,6 +70,13 @@ def new_test_graph(graph: Dict):
                     node > to_node: channel_definition['policies'][node > to_node],
                     to_node > node: channel_definition['policies'][to_node > node],
                 })
+
+            # max channel capacity
+            if not network.max_pair_capacity.get(node_pair):
+                network.max_pair_capacity[node_pair] = channel_definition['capacity']
+            else:
+                if network.max_pair_capacity[node_pair] < channel_definition['capacity']:
+                   network.max_pair_capacity[node_pair] = channel_definition['capacity']
 
     return network
 

--- a/test/test_pathfinding.py
+++ b/test/test_pathfinding.py
@@ -6,6 +6,7 @@ import networkx as nx
 
 from test import testing_common
 
+from lndmanage.lib.data_types import NodePair
 from lndmanage.lib.network import Network
 from lndmanage.lib.rating import ChannelRater
 from lndmanage.lib.pathfinding import dijkstra
@@ -44,6 +45,7 @@ def new_test_graph(graph: Dict):
             network.edges[channel] = {
                 'node1_pub': node,
                 'node2_pub': to_node,
+                'node_pair': NodePair((node, to_node)),
                 'capacity': channel_definition['capacity'],
                 'last_update': None,
                 'channel_id': channel,
@@ -61,6 +63,7 @@ def new_test_graph(graph: Dict):
                 channel_id=channel,
                 last_update=None,
                 capacity=channel_definition['capacity'],
+                node_pair=NodePair((node, to_node)),
                 fees={
                     node > to_node: channel_definition['policies'][node > to_node],
                     to_node > node: channel_definition['policies'][to_node > node],
@@ -103,16 +106,16 @@ class TestGraph(TestCase):
         self.assertEqual(['A', 'B', 'E'], path)
 
         # We report that B cannot send to E
-        network.liquidity_hints.update_cannot_send('B', 'E', 2, 1_000)
+        network.liquidity_hints.update_cannot_send('B', 'E', 1_000)
         path = dijkstra(network.graph, 'A', 'E', weight=weight_function)
         self.assertEqual(['A', 'D', 'E'], path)
 
         # We report that D cannot send to E
-        network.liquidity_hints.update_cannot_send('D', 'E', 5, 1_000)
+        network.liquidity_hints.update_cannot_send('D', 'E', 1_000)
         path = dijkstra(network.graph, 'A', 'E', weight=weight_function)
         self.assertEqual(['A', 'B', 'C', 'E'], path)
 
         # We report that D can send to C
-        network.liquidity_hints.update_can_send('D', 'C', 4, amt_msat + 1000)
+        network.liquidity_hints.update_can_send('D', 'C', amt_msat + 1000)
         path = dijkstra(network.graph, 'A', 'E', weight=weight_function)
         self.assertEqual(['A', 'D', 'C', 'E'], path)

--- a/test/test_pathfinding.py
+++ b/test/test_pathfinding.py
@@ -19,6 +19,7 @@ def new_test_graph(graph: Dict):
     # we need to init the node interface with a public key
     class MockNode:
         pub_key = 'A'
+        query_mc = lambda x: {}
 
     # we disable cached graph reading
     with mock.patch.object(Network, 'load_graph', return_value=None):


### PR DESCRIPTION
This PR synchronizes mission control data from the lnd node and populates liquidity hints, where liquidity hints are now keyed by node pubkey pairs. This way we have an easy way to benefit from the existing data if lnd is used with other tools. Liquidity hints are extended with timestamps for each individual information (can_send/cannot_send in both directions).

Todo:
- [ ] deal with number of forwarding trials when mission control data is loaded