### PR TITLE
Fix feereport key errors and numpy warnings

### DIFF
--- a/lndmanage/lib/fee_setting.py
+++ b/lndmanage/lib/fee_setting.py
@@ -220,12 +220,18 @@ class FeeSetter(object):
                 peer_number_forwardings_out += number_forwardings_out
                 peer_total_forwarding_out += total_forwarding_out
 
-                cumul_fee_rate += self.channel_fee_policies[
-                    channel_data["channel_point"]
-                ]["fee_rate"]
-                cumul_base_fee += self.channel_fee_policies[
-                    channel_data["channel_point"]
-                ]["base_fee_msat"]
+                point = channel_data["channel_point"]
+                try:
+                    policy = self.channel_fee_policies[point]
+                except KeyError:
+                    raise Exception(
+                        f"Channel {channel_id} ({point}) not found in "
+                        "feereport. This is unexpected and may mean that this "
+                        "channel is not operating correctly."
+                    )
+
+                cumul_fee_rate += policy["fee_rate"]
+                cumul_base_fee += policy["base_fee_msat"]
 
             logger.info(
                 f"    Channels with peer: {len(cs)}, "

--- a/lndmanage/lib/forwardings.py
+++ b/lndmanage/lib/forwardings.py
@@ -508,16 +508,24 @@ class ForwardingStatistics(object):
         return sum(self.outward_forwardings)
 
     def mean_forwarding_in(self) -> float:
-        return np.mean(self.inward_forwardings)
+        if len(self.inward_forwardings) > 0:
+            return np.mean(self.inward_forwardings)
+        return 0.0
 
     def mean_forwarding_out(self) -> float:
-        return np.mean(self.outward_forwardings)
+        if len(self.outward_forwardings) > 0:
+            return np.mean(self.outward_forwardings)
+        return 0.0
 
     def median_forwarding_in(self) -> float:
-        return np.median(self.inward_forwardings)
+        if len(self.inward_forwardings) > 0:
+            return np.median(self.inward_forwardings)
+        return 0.0
 
     def median_forwarding_out(self) -> float:
-        return np.median(self.outward_forwardings)
+        if len(self.outward_forwardings) > 0:
+            return np.median(self.outward_forwardings)
+        return 0.0
 
     def total_fees_out(self) -> int:
         return sum(self.fees_out)


### PR DESCRIPTION
Fixes #144.

Also fixes warnings related to
```
/root/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3464: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
/root/.venv/lib/python3.10/site-packages/numpy/core/_methods.py:192: RuntimeWarning: invalid value encountered in scalar divide
  ret = ret.dtype.type(ret / rcount)
```